### PR TITLE
Final revision of the 1.3 schema

### DIFF
--- a/teams/v1.3/MicrosoftTeams.schema.json
+++ b/teams/v1.3/MicrosoftTeams.schema.json
@@ -455,27 +455,6 @@
                 "type": "string",
                 "maxLength": 2048
             }
-        },
-        "webApplicationInfo": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string",
-                    "description": "AAD application id of the app. This id must be a GUID.",
-                    "maxLength": 36,
-                    "pattern": "^[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}$"
-                },
-                "resource": {
-                    "type": "string",
-                    "description": "Resource url of app for acquiring auth token for SSO.",
-                    "maxLength": 2048
-                }
-            },
-            "required": [
-                "id",
-                "resource"
-            ],
-            "additionalProperties": false
         }
     },
     "required": [


### PR DESCRIPTION
Removing the webApplicationInfo section because it is not available in the Teams client.