### PR TITLE
Add note to call out limitation cases in json

### DIFF
--- a/office-js/custom-functions.schema.json
+++ b/office-js/custom-functions.schema.json
@@ -45,17 +45,17 @@
                         "properties": {
                             "cancelable": {
                                 "type": "boolean",
-                                "title": "Indicates whether the function can be cancelled when it's running.  Default is false.",
+                                "title": "Indicates the function can be cancelled when it's running.  Default is false.",
                                 "default": false
                             },
                             "stream": {
                                 "type": "boolean",
-                                "title": "Indicates whether the function is a streaming function that is continuously updated. Default is false.",
+                                "title": "Indicates the function is a streaming function that is continuously updated. Default is false. This flag cannot be set on a function that is also declared as volatile.",
                                 "default": false
                             },
                             "requiresAddress": {
                                 "type": "boolean",
-                                "title": "Indicates whether the function requires the cell address of the calling cell. Default is false.",
+                                "title": "Indicates the function requires the cell address of the calling cell. Default is false. This flag cannot be set on a function that is also declared as a streaming function.",
                                 "default": false
                             }
                         },


### PR DESCRIPTION
Call this out in JSON so developers see it in autocomplete context.