### PR TITLE
Update column-formatting.schema.json

### DIFF
--- a/sp/v2/column-formatting.schema.json
+++ b/sp/v2/column-formatting.schema.json
@@ -465,7 +465,7 @@
       "properties": {
         "fileTypeIconClass": {
           "description": "Class name or an Expression which evaluates to one, to add to the FileTypeIcon",
-          "$ref": "#/properties/attributes/class"
+          "$ref": "#/properties/attributes/properties/class"
         },
         "fileTypeIconStyle": {
           "description": "Style object or an Expression which evaluates to one, to add to the FileTypeIcon",
@@ -473,7 +473,7 @@
         },
         "brandTypeIconClass": {
           "description": "Class name or an Expression which evaluates to one, to add to the BrandTypeIcon",
-          "$ref": "#/properties/attributes/class"
+          "$ref": "#/properties/attributes/properties/class"
         },
         "brandTypeIconStyle": {
           "description": "Style object or an Expression which evaluates to one, to add to the BrandTypeIcon",


### PR DESCRIPTION
Fixed `$ref` for `#/properties/filePreviewProps/properties/fileTypeIconClass` and `#/properties/filePreviewProps/properties/brandTypeIconClass`

These are causing errors in the Monaco Editor as it is unable to correctly parse the schema because of the bad references:

![image](https://user-images.githubusercontent.com/8364109/173862387-c61c7913-6dd7-454a-aaa3-d1528d31966e.png)
