### PR TITLE
Update view-formatting.schema.json

### DIFF
--- a/sp/v2/view-formatting.schema.json
+++ b/sp/v2/view-formatting.schema.json
@@ -86,7 +86,7 @@
               "hide": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/expression"
+                    "$ref": "https://developer.microsoft.com/json-schemas/sp/v2/column-formatting.schema.json#/definitions/expression"
                   },
                   {
                     "type": "boolean"
@@ -102,7 +102,7 @@
               "position": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/expression"
+                    "$ref": "https://developer.microsoft.com/json-schemas/sp/v2/column-formatting.schema.json#/definitions/expression"
                   },
                   {
                     "type": "number"
@@ -116,7 +116,7 @@
               "primary": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/expression"
+                    "$ref": "https://developer.microsoft.com/json-schemas/sp/v2/column-formatting.schema.json#/definitions/expression"
                   },
                   {
                     "type": "boolean"
@@ -132,7 +132,7 @@
               "text": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/expression"
+                    "$ref": "https://developer.microsoft.com/json-schemas/sp/v2/column-formatting.schema.json#/definitions/expression"
                   },
                   {
                     "type": "string"
@@ -142,7 +142,7 @@
               "iconName": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/expression"
+                    "$ref": "https://developer.microsoft.com/json-schemas/sp/v2/column-formatting.schema.json#/definitions/expression"
                   },
                   {
                     "type": "string"
@@ -152,7 +152,7 @@
               "title": {
                 "anyOf": [
                   {
-                    "$ref": "#/definitions/expression"
+                    "$ref": "https://developer.microsoft.com/json-schemas/sp/v2/column-formatting.schema.json#/definitions/expression"
                   },
                   {
                     "type": "string"


### PR DESCRIPTION
expression definitions were incorrectly specified as in-schema references. Changed these to be cross-schema references. This is because `expression` is not defined in this schema, but rather in the column-formatting schema.