### PR TITLE
Update row-formatting.schema.json

### DIFF
--- a/sp/v2/row-formatting.schema.json
+++ b/sp/v2/row-formatting.schema.json
@@ -14,11 +14,11 @@
     },
     "rowFormatter": {
       "description": "JSON object that defines formatting of a row.",
-      "$ref": "https://developer.microsoft.com/json-schemas/sp/v2/column-formatting.schema.json#"
+      "$ref": "https://developer.microsoft.com/json-schemas/sp/v2/column-formatting.schema.json"
     },
     "additionalRowClass": {
       "description": "CSS class(es) that is applied to the entire row. Supports expressions. Only valid for 'List' and 'Compact List' layouts.",
-      "$ref": "https://developer.microsoft.com/json-schemas/sp/v2/column-formatting.schema.json#definitions/expression"
+      "$ref": "https://developer.microsoft.com/json-schemas/sp/v2/column-formatting.schema.json#/definitions/expression"
     },
     "groupProps": {
       "type": "object",
@@ -26,7 +26,7 @@
       "properties": {
         "headerFormatter": {
           "description": "JSON object that defines formatting for the group headers",
-          "$ref": "https://developer.microsoft.com/json-schemas/sp/v2/column-formatting.schema.json#"
+          "$ref": "https://developer.microsoft.com/json-schemas/sp/v2/column-formatting.schema.json"
         },
         "hideFooter": {
           "description": "Boolean value to hide the group footer",
@@ -34,7 +34,7 @@
         },
         "footerFormatter": {
           "description": "JSON object that defines formatting for the group footers",
-          "$ref": "https://developer.microsoft.com/json-schemas/sp/v2/column-formatting.schema.json#"
+          "$ref": "https://developer.microsoft.com/json-schemas/sp/v2/column-formatting.schema.json"
         }
       }
     },
@@ -44,11 +44,11 @@
     },
     "footerFormatter": {
       "description": "JSON object that defines formatting for the list footer",
-      "$ref": "https://developer.microsoft.com/json-schemas/sp/v2/column-formatting.schema.json#"
+      "$ref": "https://developer.microsoft.com/json-schemas/sp/v2/column-formatting.schema.json"
     },
     "commandBarProps": {
       "description": "JSON object that defines command bar customization options",
-      "$ref": "https://developer.microsoft.com/json-schemas/sp/v2/view-formatting.schema.json#definitions/commandBarProps"
+      "$ref": "https://developer.microsoft.com/json-schemas/sp/v2/view-formatting.schema.json#/definitions/commandBarProps"
     }
   }
 }


### PR DESCRIPTION
Fixed schema references to include slash after the `#` which is required. Also, removed unnecessary `#`s from full references.

FYI @shagra-ms 