### PR TITLE
Update calendar-formatting.schema.json

### DIFF
--- a/sp/v2/calendar-formatting.schema.json
+++ b/sp/v2/calendar-formatting.schema.json
@@ -10,7 +10,7 @@
       "properties": {
         "commandBarProps": {
           "description": "JSON object that defines command bar customization options",
-          "$ref": "https://developer.microsoft.com/json-schemas/sp/v2/view-formatting.schema.json#definitions/commandBarProps"
+          "$ref": "https://developer.microsoft.com/json-schemas/sp/v2/view-formatting.schema.json#/definitions/commandBarProps"
         }
       }
     }


### PR DESCRIPTION
Fixed schema reference to include slash after the `#` which is required.

FYI @shagra-ms 