### PR TITLE
Update board-formatting.schema.json

### DIFF
--- a/sp/v2/board-formatting.schema.json
+++ b/sp/v2/board-formatting.schema.json
@@ -10,11 +10,11 @@
     },
     "formatter": {
       "description": "JSON object that defines formatting of a card.",
-      "$ref": "https://developer.microsoft.com/json-schemas/sp/v2/column-formatting.schema.json#"
+      "$ref": "https://developer.microsoft.com/json-schemas/sp/v2/column-formatting.schema.json"
     },
     "commandBarProps": {
       "description": "JSON object that defines command bar customization options",
-      "$ref": "https://developer.microsoft.com/json-schemas/sp/v2/view-formatting.schema.json#definitions/commandBarProps"
+      "$ref": "https://developer.microsoft.com/json-schemas/sp/v2/view-formatting.schema.json#/definitions/commandBarProps"
     }
   }
 }


### PR DESCRIPTION
Fixed schema references to include slash after the `#` which is required. Also, removed unnecessary `#`s from full references.

FYI @shagra-ms 