### PR TITLE
created git integration json schema  v2

### DIFF
--- a/fabric/git-integration/v2/platform-properties.schema.json
+++ b/fabric/git-integration/v2/platform-properties.schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "trident artifact git integration configuration",
+  "description": "configuration file used by fabric git integration on artifacts in git repositories",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "link to json schema in json repository"
+    },
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "the type of the artifact"
+        },
+        "displayName": {
+          "type": "string",
+          "description": "how the artifact is listed in the UI"
+        }
+      },
+      "required": ["type", "displayName"]
+    },
+    "config": {
+      "type": "object",
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "the version of the the metadata"
+        },
+        "logicalId": {
+          "type": "string",
+          "description": "logical ID of the artifact"
+        }
+      },
+      "required": ["version", "logicalId"]
+    }
+  },
+  "required": ["$schema", "metadata", "config"]
+}


### PR DESCRIPTION
this is the first published version of the json schema used by fabric's git integration feature.

v1 will not be available during GA so it won't be published.