### PR TITLE
Add `isRequired` field in parameters object for Teams manifest

### DIFF
--- a/teams/vDevPreview/MicrosoftTeams.schema.json
+++ b/teams/vDevPreview/MicrosoftTeams.schema.json
@@ -697,7 +697,8 @@
                                                 "default": "text"
                                             },
                                             "isRequired": {
-                                                "type": "boolean"
+                                                "type": "boolean",
+                                                "description": "Indicates whether this parameter is required or not. By default, it is not."
                                             },
                                             "title": {
                                                 "type": "string",

--- a/teams/vDevPreview/MicrosoftTeams.schema.json
+++ b/teams/vDevPreview/MicrosoftTeams.schema.json
@@ -696,6 +696,9 @@
                                                 "description": "Type of the parameter",
                                                 "default": "text"
                                             },
+                                            "isRequired": {
+                                                "type": "boolean"
+                                            },
                                             "title": {
                                                 "type": "string",
                                                 "description": "Title of the parameter.",


### PR DESCRIPTION
The `isRequired` field was added to the parameter object that would allow simple validation to indicate whether a field was required or not. By default, the parameter is not required (and this maintains backward compatibility). If the field is set to true, then the client will perform validation when the form is submitted to ensure that value for the parameter is provided.

(My msft alias is: aamirjawaid, for any questions)