### PR TITLE
Add `isRequired` field to parameters object

### DIFF
--- a/teams/vDevPreview/MicrosoftTeams.schema.json
+++ b/teams/vDevPreview/MicrosoftTeams.schema.json
@@ -696,6 +696,10 @@
                                                 "description": "Type of the parameter",
                                                 "default": "text"
                                             },
+                                            "isRequired": {
+                                                "type": "boolean",
+                                                "description": "Indicates whether this parameter is required or not. By default, it is not."
+                                            },
                                             "title": {
                                                 "type": "string",
                                                 "description": "Title of the parameter.",


### PR DESCRIPTION
The isRequired field was added to the parameter object that would allow simple validation to indicate whether a field was required or not. By default, the parameter is not required (and this maintains backward compatibility). If the field is set to true, then the client will perform validation when the form is submitted to ensure that value for the parameter is provided.

(My msft alias is: aamirjawaid, for any questions)

(Here is the main branch PR - https://github.com/microsoft/json-schemas/pull/189)