### PR TITLE
Automate Microsoft 365 app manifest schema release

### DIFF
--- a/.github/workflows/auto-create-manifest-schema-release-pr.yml
+++ b/.github/workflows/auto-create-manifest-schema-release-pr.yml
@@ -1,0 +1,67 @@
+name: Auto Create Manifest Schema Release PR
+
+# This section defines when the action should trigger.
+on:
+  push:
+    paths:
+      - 'teams/**'
+    branches-ignore:
+      - main
+      - live
+
+jobs:
+  create-pr:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Push the changes back to the repo.
+      - name: Push changes
+        run: git push origin HEAD
+
+      # Create a Pull Request to the main branch.
+      - name: Create PR to main
+        uses: repo-sync/pull-request@v2
+        with:
+          id: local_to_main_pr
+          source_branch: ${{ github.ref }}
+          destination_branch: main
+          pr_title: "Add / Update new schema files"
+          pr_body: "This PR adds or updates app and localization schema files to the repo's main branch"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Poll for PR status until it's closed
+      - name: Monitor PR status
+        run: |
+          PR_NUMBER=${{ steps.local_to_main_pr.pull_request_number }}
+          while [ "$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER | jq -r .state)" != "closed" ]; do
+              echo "PR #$PR_NUMBER is not closed yet..."
+              sleep 10
+          done
+          echo "PR local to main with number #$PR_NUMBER has been closed!"
+        env:
+          PR_NUMBER: ${{ steps.local_to_main_pr.outputs.pull_request_number }}
+
+      # Once closed, Create a PR from the main branch to live
+      - name: Create PR to main
+        uses: repo-sync/pull-request@v2
+        with:
+          id: main_to_live_pr
+          source_branch: main
+          destination_branch: live
+          pr_title: "Merge main to live"
+          pr_body: "This PR adds or updates app and localization schema files from the main branch to the live branch"
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Poll for PR status until it's closed
+      - name: Monitor PR status
+        run: |
+          PR_NUMBER=${{ steps.main_to_live_pr.pull_request_number }}
+          while [ "$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              https://api.github.com/repos/${{ github.repository }}/pulls/$PR_NUMBER | jq -r .state)" != "closed" ]; do
+              echo "PR #$PR_NUMBER is not closed yet..."
+              sleep 10
+          done
+          echo "PR main to live with number #$PR_NUMBER has been closed!"
+        env:
+          PR_NUMBER: ${{ steps.main_to_live_pr.outputs.pull_request_number }}


### PR DESCRIPTION
The GitHub worklow described below aims to automate the process of releasing Microsoft 365 app manifest schemas.
STEPS:

- It only is triggered when pushes are made to the repo folder teams.
- It creates a PR from the working branch to main.
- It checks for completion and then creates a PR from main to live. 