### PR TITLE
Org app schema: Remove min size constraint for overview body

### DIFF
--- a/fabric/item/orgapp/definition/orgAppDefinition/1.0.0/schema.json
+++ b/fabric/item/orgapp/definition/orgAppDefinition/1.0.0/schema.json
@@ -392,7 +392,6 @@
           "type": [
             "string"
           ],
-          "minLength": 1,
           "maxLength": 2500
         },
         "showTheme": {


### PR DESCRIPTION
There is no min size constraint for overview item's body.