### PR TITLE
Update UserDataFunctions schema to include private libraries

### DIFF
--- a/fabric/item/userDataFunction/definition/1.1.0/schema.json
+++ b/fabric/item/userDataFunction/definition/1.1.0/schema.json
@@ -1,0 +1,145 @@
+{
+  "$id": "https://developer.microsoft.com/json-schemas/fabric/item/userDataFunction/definition/1.1.0/schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "User data functions",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "runtime": {
+      "enum": [
+        "NOTASSIGNED",
+        "DOTNET",
+        "PYTHON"
+      ]
+    },
+    "connectedDataSources": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "artifactId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "artifactType": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "dmtsConnectionId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "workspaceId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      }
+    },
+    "functions": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "isPublicEndpointEnabled": {
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        }
+      }
+    },
+    "libraries": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "public": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "enum": [
+                  "PYPI",
+                  "WHEEL"
+                ]
+              },
+              "version": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
+        "private": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "enum": [
+                  "PYPI",
+                  "WHEEL"
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/fabric/item/userDataFunction/definition/CHANGELOG.md
+++ b/fabric/item/userDataFunction/definition/CHANGELOG.md
@@ -1,0 +1,11 @@
+### 1.1.0
+
+<b>Released in: </b> April 2025 <br />
+<b>Notes: </b> 
+- Differentiates between two types of `libraries`: `public` and `private`
+
+### 1.0.0
+
+<b>Released in: </b> February 2025 <br />
+<b>Notes: </b> 
+- Initial release of the user data functions schema


### PR DESCRIPTION
Fabric User Data Functions recently added private libraries to their python functions. This change updates the item schema to include private libraries