### PR TITLE
Copilot schemas : Fix bug introduced due to merged conflict fix 

### DIFF
--- a/copilot/declarative-agent/v1.3/schema.json
+++ b/copilot/declarative-agent/v1.3/schema.json
@@ -557,17 +557,6 @@
                 "search_associated_sites": {
                     "type": "boolean",
                     "description": "Boolean value indicating whether to enable searching associated sites. This value is only applicable when the site_id value references a SharePoint HubSite."
-                },
-                "part_id": {
-                    "type": "string",
-                    "description": "A JSON String that uniquely identifies a part of a SharePoint item. e.g a OneNote page."
-                },
-                "part_type": {
-                    "type": "string",
-                    "description": "A String that qualifies the kind of part that the \"part_id\" refers to. Currently this value can only be equal to the string literal: \"OneNotePart\".",
-                    "enum": [
-                        "OneNotePart"
-                    ]
                 }
             },
             "propertyNames": {
@@ -576,9 +565,6 @@
                     "web_id",
                     "list_id",
                     "unique_id",
-                    "search_associated_sites",
-                    "part_id",
-                    "part_type"
                     "search_associated_sites"
                 ]
             },


### PR DESCRIPTION
- Remove `part_id` and `part_type` as it is now part of v1.4 
- Fix issue with syntax that was introduced in this commit:  https://github.com/microsoft/json-schemas/commit/45e592bcf1ea10ec4dc24fc973cc134863716407