### PR TITLE
DeclarativeAgents - Live: Remove Disclaimer from DA Manifest v1.4

### DIFF
--- a/copilot/declarative-agent/v1.4/schema.json
+++ b/copilot/declarative-agent/v1.4/schema.json
@@ -29,9 +29,6 @@
             "maxLength": 1000,
             "pattern": "^(\\[\\[)[a-zA-Z_][a-zA-Z0-9_]*(\\]\\])$|^(?!(.*?\\[\\[.*?|.*?\\]\\].*?)).*$"
         },
-        "disclaimer": {
-            "$ref": "#/$defs/disclaimer"
-        },
         "instructions": {
             "type": "string",
             "description": "Optional. Not localizable. The detailed instructions or guidelines on how the declarative agent should behave, its functions, and any behaviors to avoid. It MUST contain at least one nonwhitespace character and MUST be 8,000 characters or less.",
@@ -89,7 +86,6 @@
             "version",
             "name",
             "description",
-            "disclaimer",
             "instructions",
             "capabilities",
             "behavior_overrides",
@@ -99,17 +95,6 @@
         ]
     },
     "$defs": {
-        "disclaimer": {
-            "type": "object",
-            "description":  "An optional JSON object containing a disclaimer message which, if provided, will be displayed users at the start of a conversation to satisfy legal or compliance requirements. The object has a required text string property which MUST NOT be null and MUST contain at least 1 non-whitespace character. Characters beyond 500 MAY be ignored.",
-            "properties": {
-                "text": {
-                    "type": "string",
-                    "description": "",
-                    "minLength": 1
-                }
-            }
-        },
         "capabilities": {
             "base-capability": {
                 "type": "object",


### PR DESCRIPTION
Port of #379.

This PR removes disclaimer from the DeclarativeAgents manifest 1.4 as the platform team does currently not support it.

Fixes https://github.com/microsoft/Microsoft.Plugins.Manifest/issues/605
