### PR TITLE
Teams Manifest | Fix bot and command max scopes | v1.21 v1.22

### DIFF
--- a/teams/v1.21/MicrosoftTeams.schema.json
+++ b/teams/v1.21/MicrosoftTeams.schema.json
@@ -377,8 +377,8 @@
           },
           "scopes": {
             "type": "array",
-            "description": "Specifies whether the bot offers an experience in the context of a channel in a team, in a 1:1 or group chat, or in an experience scoped to an individual user alone. These options are non-exclusive.",
-            "maxItems": 3,
+            "description": "Specifies whether the bot offers an experience in the context of a channel in a team, in a group chat (groupChat), an experience scoped to an individual user alone (personal) OR within Copilot surfaces. These options are non-exclusive.",
+            "maxItems": 4,
             "items": {
               "enum": [
                 "team",
@@ -399,7 +399,7 @@
                 "scopes": {
                   "type": "array",
                   "description": "Specifies the scopes for which the command list is valid",
-                  "maxItems": 3,
+                  "maxItems": 4,
                   "items": {
                     "enum": [
                       "team",

--- a/teams/v1.22/MicrosoftTeams.schema.json
+++ b/teams/v1.22/MicrosoftTeams.schema.json
@@ -377,8 +377,8 @@
           },
           "scopes": {
             "type": "array",
-            "description": "Specifies whether the bot offers an experience in the context of a channel in a team, in a 1:1 or group chat, or in an experience scoped to an individual user alone. These options are non-exclusive.",
-            "maxItems": 3,
+            "description": "Specifies whether the bot offers an experience in the context of a channel in a team, in a group chat (groupChat), an experience scoped to an individual user alone (personal) OR within Copilot surfaces. These options are non-exclusive.",
+            "maxItems": 4,
             "items": {
               "enum": [
                 "team",
@@ -399,7 +399,7 @@
                 "scopes": {
                   "type": "array",
                   "description": "Specifies the scopes for which the command list is valid",
-                  "maxItems": 3,
+                  "maxItems": 4,
                   "items": {
                     "enum": [
                       "team",

--- a/teams/vDevPreview/MicrosoftTeams.schema.json
+++ b/teams/vDevPreview/MicrosoftTeams.schema.json
@@ -497,7 +497,7 @@
                             "properties": {
                                 "scopes": {
                                     "type": "array",
-                                    "description": "Specifies whether the bot offers an experience in the context of a channel in a team, in a group chat (groupChat), an experience scoped to an individual user alone (personal) OR within Copilot surfaces. These options are non-exclusive.",
+                                    "description": "Specifies the scopes for which the command list is valid",
                                     "maxItems": 4,
                                     "items": {
                                       "enum": [


### PR DESCRIPTION
There was an error publishing v1.21 and v1.22 manifest schemas, where max scopes allowed for bots and commands were not updated to 4.