### PR TITLE
Version 2.0.0 for PBIR reflecting connection properties

### DIFF
--- a/fabric/item/report/definitionProperties/2.0.0/schema.json
+++ b/fabric/item/report/definitionProperties/2.0.0/schema.json
@@ -1,0 +1,82 @@
+
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://developer.microsoft.com/json-schemas/fabric/item/report/definitionProperties/2.0.0/schema.json",
+  "title": "ReportDefinition",
+  "description": "The ReportDefinition is stored as definition.pbir. It contains metadata about the overall file structure, holds core settings, and holds a reference to the semantic model used by this report. This file is required.",
+  "definitions": {
+    "DatasetReference": {
+      "title": "DatasetReference",
+      "description": "The DatasetReference defines the semantic model that is bound to this report. It is required to have exactly one of either the byPath or byConnection properties. The byConnection property would typically be used for LiveConnect scenarios whereas byPath would point at a local semantic model.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "byPath": {
+          "$ref": "#/definitions/ReportDatasetReferenceByPath"
+        },
+        "byConnection": {
+          "$ref": "#/definitions/ReportDatasetReferenceByConnection"
+        }
+      }
+    },
+    "ReportDatasetReferenceByConnection": {
+      "title": "ByConnection",
+      "description": "Provides a reference to a remote semantic model using a connection string. The connection string must point to a semantic model hosted in the Microsoft Fabric service.  Connections to other Analysis Services semantic models must use a byPath reference to a semantic model definition containing a modelReference.json file.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "connectionString": {
+          "title": "ConnectionString",
+          "description": "The connection string referring to the remote semantic model.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "connectionString"
+      ]
+    },
+    "ReportDatasetReferenceByPath": {
+      "title": "ByPath",
+      "description": "Provides a reference to a local dataset artifact definition.",
+      "type": [
+        "object",
+        "null"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "title": "Path",
+          "description": "A relative path from this file to the target semantic model artifact folder. Uses ‘/’ as a directory separator.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path"
+      ]
+    }
+  },
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "pattern": "^https://developer.microsoft.com/json-schemas/fabric/item/report/definitionProperties/2.[0-9]+.[0-9]+/schema.json$"
+    },
+    "version": {
+      "title": "Version",
+      "description": "Version of the report artifact file format.  This also serves as the version number for the .pbir file format.",
+      "type": "string"
+    },
+    "datasetReference": {
+      "$ref": "#/definitions/DatasetReference"
+    }
+  },
+  "required": [
+    "$schema",
+    "version",
+    "datasetReference"
+  ]
+}


### PR DESCRIPTION
Version 2.0.0 removes several properties from byConnection object and leaves just the connection string.