### PR TITLE
fix: Fix allowed_host Type in Plugin Manifest v2.3 Schema

### DIFF
--- a/copilot/plugin/v2.3/schema.json
+++ b/copilot/plugin/v2.3/schema.json
@@ -460,14 +460,17 @@
                     ]
                 },
                 "allowed_host": {
-                    "type": "string",
+                    "type": "array",
                     "description": "An optional JSON array of enumerated strings that can take values as mail, workbook, document or presentation. The value represent the host apps this LocalPlugin can run-in.",
-                    "enum": [
-                        "mail",
-                        "workbook",
-                        "document",
-                        "presentation"
-                    ]
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "mail",
+                            "workbook",
+                            "document",
+                            "presentation"
+                        ]
+                    }
                 }
             },
             "additionalProperties": false,


### PR DESCRIPTION
This PR corrects the `allowed_host` property in the Copilot Plugin manifest v2.3 schema by changing its type from a single string to an array of strings with enum constraints.

Fixes #https://github.com/microsoft/Microsoft.Plugins.Manifest/issues/617.

#### Before
<img width="719" height="367" alt="image" src="https://github.com/user-attachments/assets/aa766c80-3029-4589-9bd5-d391899be897" />

#### After
<img width="1248" height="377" alt="image" src="https://github.com/user-attachments/assets/928c8e6b-3d91-4a98-b75a-479d0c0b56f2" />

