### PR TITLE
Add fabirc scheduler cicd schema

### DIFF
--- a/fabric/gitIntegration/schedules/1.0.0/schema.json
+++ b/fabric/gitIntegration/schedules/1.0.0/schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Fabric item schedules Git integration configuration ",
+  "title": "Fabric item schedules Git integration configuration",
   "description": "Configuration file used by fabric Git integration on item schedules in Git repositories",
   "type": "object",
   "properties": {
@@ -20,7 +20,7 @@
         "properties": {
             "enabled": {
                 "type": "boolean",
-                "description": "Whether this schedule is enabled. True - Enabled, False - Disabled."
+                "description": "Whether this schedule is enabled. True - Enabled, False - Disabled"
             },
             "jobType": {
                 "type": "string",
@@ -28,7 +28,7 @@
             },
             "configuration": {
                 "$ref": "#/definitions/scheduleConfiguration",
-                "description": "The actual data contains the time/weekdays of this schedule."
+                "description": "The actual data contains the time/weekdays of this schedule"
             }
         },
         "required": ["enabled", "jobType", "configuration"]
@@ -37,37 +37,37 @@
         "type": "object",
         "properties": {
             "type": {
-                "description": "A string represents the type of the schedule.",
+                "description": "A string represents the type of the schedule",
                 "type": "string",
                 "enum": [ "Cron", "Daily", "Weekly", "Monthly" ]
             },
             "startDateTime": {
-                "description": "The start time for this schedule.",
+                "description": "The start time for this schedule",
                 "type": "string",
                 "format": "date-time"
             },
             "endDateTime": {
-                "description": "The end time for this schedule.",
+                "description": "The end time for this schedule",
                 "type": "string",
                 "format": "date-time"
             },
             "localTimeZoneId": {
-                "description": "The time zone identifier registry on local computer for windows.",
+                "description": "The time zone identifier registry on local computer for windows",
                 "type": "string"
             },
             "interval": {
-                "description": "The time interval in minutes.",
+                "description": "The time interval in minutes",
                 "type": "number"
             },
             "times": {
-                "description": "A list of time slots in hh:mm format, at most 100 elements are allowed.",
+                "description": "A list of time slots in hh:mm format, at most 100 elements are allowed",
                 "type": "array",
                 "items": {
                     "type": "string"
                 }
             },
             "weekdays": {
-                "description": "A list of weekdays, at most seven elements are allowed.",
+                "description": "A list of weekdays, at most seven elements are allowed",
                 "type": "array",
                 "items": {
                     "$ref": "#/definitions/dayOfWeek"
@@ -81,7 +81,7 @@
                 }
             },
             "recurrence": {
-                "description": "Specifies the monthly job repeat interval. For example, when set to 1 the job is triggered every month.",
+                "description": "Specifies the monthly job repeat interval. For example, when set to 1 the job is triggered every month",
                 "type": "number"
             },
             "occurrence": {

--- a/fabric/gitIntegration/schedules/1.0.0/schema.json
+++ b/fabric/gitIntegration/schedules/1.0.0/schema.json
@@ -110,7 +110,7 @@
             },
             "value": {
                 "description": "Parameter value",
-                "type": "object"
+                "type": "string"
             }
         },
         "required": ["name", "type", "value"]

--- a/fabric/gitIntegration/schedules/1.0.0/schema.json
+++ b/fabric/gitIntegration/schedules/1.0.0/schema.json
@@ -1,0 +1,143 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Fabric item schedules Git integration configuration ",
+  "description": "Configuration file used by fabric Git integration on item schedules in Git repositories",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Link to json schema in json repository"
+    },
+    "schedules": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/schedule" }
+    }
+  },
+  "required": ["$schema", "schedules"],
+  "definitions": {
+    "schedule": {
+        "type": "object",
+        "properties": {
+            "enabled": {
+                "type": "boolean",
+                "description": "Whether this schedule is enabled. True - Enabled, False - Disabled."
+            },
+            "jobType": {
+                "type": "string",
+                "description": "The job type."
+            },
+            "configuration": {
+                "$ref": "#/definitions/scheduleConfiguration",
+                "description": "The actual data contains the time/weekdays of this schedule."
+            }
+        },
+        "required": ["enabled", "jobType", "configuration"]
+    },
+    "scheduleConfiguration": {
+        "type": "object",
+        "properties": {
+            "type": {
+                "description": "A string represents the type of the schedule.",
+                "type": "string",
+                "enum": [ "Cron", "Daily", "Weekly", "Monthly" ]
+            },
+            "startDateTime": {
+                "description": "The start time for this schedule.",
+                "type": "string",
+                "format": "date-time"
+            },
+            "endDateTime": {
+                "description": "The end time for this schedule.",
+                "type": "string",
+                "format": "date-time"
+            },
+            "localTimeZoneId": {
+                "description": "The time zone identifier registry on local computer for windows.",
+                "type": "string"
+            },
+            "interval": {
+                "description": "The time interval in minutes.",
+                "type": "number"
+            },
+            "times": {
+                "description": "A list of time slots in hh:mm format, at most 100 elements are allowed.",
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "weekdays": {
+                "description": "A list of weekdays, at most seven elements are allowed.",
+                "type": "array",
+                "items": {
+                    "$ref": "#/definitions/dayOfWeek"
+                }
+            },
+            "parameters": {
+                "description": "A list of parameters",
+                "type": "array",
+                "items": {
+                    "$ref": "#/definitions/parameter"
+                }
+            },
+            "recurrence": {
+                "description": "Specifies the monthly job repeat interval. For example, when set to 1 the job is triggered every month.",
+                "type": "number"
+            },
+            "occurrence": {
+                "description": "Specifies the day for triggering jobs",
+                "$ref": "#/definitions/monthlyOccurrence"
+            }
+        },
+        "required": ["type"]
+    },
+    "dayOfWeek":{
+        "type": "string",
+        "enum": [ "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday",  "Friday", "Saturday" ]
+    },
+    "parameter": {
+        "type": "object",
+        "description": "Job parameter.",
+        "properties": {
+            "name": {
+                "description": "Parameter name",
+                "type": "string"
+            },
+            "type": {
+                "description": "Parameter type",
+                "type": "string",
+                "enum": [ "VariableReference"]
+            },
+            "value": {
+                "description": "Parameter value",
+                "type": "object"
+            }
+        },
+        "required": ["name", "type", "value"]
+    },
+    "monthlyOccurrence": {
+        "type": "object",
+        "properties": {
+            "occurrenceType": {
+                "description": "Occurrence type",
+                "type": "string",
+                "enum": [ "DayOfMonth", "OrdinalWeekday"]
+            },
+            "dayOfMonth": {
+                "description": "Specifies a date to trigger the job, using a value between 1 and 31",
+                "type": "number"
+            },
+            "weekIndex": {
+                "description": "The week of the month",
+                "type": "string",
+                "enum": [ "First", "Second", "Third", "Fourth", "Fifth" ]
+            },
+            "WeekDay": {
+                "description": "Week day for triggering jobs",
+                "$ref": "#/definitions/dayOfWeek"
+            }
+        },
+        "required": ["type"]
+    }
+  }
+}

--- a/fabric/gitIntegration/schedules/1.0.0/schema.json
+++ b/fabric/gitIntegration/schedules/1.0.0/schema.json
@@ -137,7 +137,7 @@
                 "$ref": "#/definitions/dayOfWeek"
             }
         },
-        "required": ["type"]
+        "required": ["occurrenceType"]
     }
   }
 }


### PR DESCRIPTION
This PR adds schema used by fabric Git integration on item schedules in Git repositories