### PR TITLE
feat: Adds Copilot DA 1.5 schema

### DIFF
--- a/copilot/declarative-agent/v1.5/schema.json
+++ b/copilot/declarative-agent/v1.5/schema.json
@@ -1,0 +1,904 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$comment": "This schema describes the constraints of a declarative agent for third party developers to be deployed to Microsoft 365 Copilot",
+    "type": "object",
+    "title": "Declarative agent manifest object",
+    "description": "The root of the declarative agent manifest document is a JSON object that contains members that describe the declarative agent.",
+    "properties": {
+        "version": {
+            "description": "Required. Not localizable. The version of the schema this manifest is using.",
+            "type": "string",
+            "const": "v1.5"
+        },
+        "id": {
+            "description": "Optional. Not localizable.",
+            "type": "string",
+            "pattern": "^(?!\\[\\[)(.*?)(?<!\\]\\])$"
+        },
+        "name": {
+            "type": "string",
+            "description": "Required. Localizable. The name of the declarative agent. It MUST contain at least one nonwhitespace character and MUST be 100 characters or less.",
+            "minLength": 1,
+            "maxLength": 100,
+            "pattern": "^(\\[\\[)[a-zA-Z_][a-zA-Z0-9_]*(\\]\\])$|^(?!(.*?\\[\\[.*?|.*?\\]\\].*?)).*$"
+        },
+        "description": {
+            "type": "string",
+            "description": "Required. Localizable. The description of the declarative agent. It MUST contain at least one nonwhitespace character and MUST be 1,000 characters or less.",
+            "minLength": 1,
+            "maxLength": 1000,
+            "pattern": "^(\\[\\[)[a-zA-Z_][a-zA-Z0-9_]*(\\]\\])$|^(?!(.*?\\[\\[.*?|.*?\\]\\].*?)).*$"
+        },
+        "disclaimer": {
+            "$ref": "#/$defs/disclaimer"
+        },
+        "instructions": {
+            "type": "string",
+            "description": "Optional. Not localizable. The detailed instructions or guidelines on how the declarative agent should behave, its functions, and any behaviors to avoid. It MUST contain at least one nonwhitespace character and MUST be 8,000 characters or less.",
+            "minLength": 1,
+            "maxLength": 8000,
+            "pattern": "^(?!\\[\\[)((.|\\n|\\r)*?)(?<!\\]\\])$"
+        },
+        "behavior_overrides": {
+            "description": "Optional. A JSON object that contains configuration settings that modify the behavior of the DA orchestration.",
+            "$ref": "#/$defs/behavior-overrides"
+        },
+        "capabilities": {
+            "type": "array",
+            "description": "Optional. Contains an array of objects that define capabilities of the declarative agent.",
+            "uniqueItems": true,
+            "items": {
+                "anyOf": [
+                    {
+                        "$ref": "#/$defs/capabilities/base-capability"
+                    }
+                ]
+            }
+        },
+        "conversation_starters": {
+            "type": "array",
+            "description": "Optional. A list of examples of questions that the declarative agent can answer. There MUST NOT be more than six objects in the array.",
+            "maxItems": 6,
+            "minItems": 1,
+            "items": {
+                "$ref": "#/$defs/conversation-starter"
+            }
+        },
+        "actions": {
+            "type": "array",
+            "description": "Optional. A list of objects that identify API plugins that provide actions accessible to the declarative agent.",
+            "minItems": 1,
+            "maxItems": 10,
+            "items": {
+                "oneOf": [
+                    {
+                        "$ref": "#/$defs/action-object"
+                    }
+                ]
+            }
+        }
+    },
+    "required": [
+        "version",
+        "name",
+        "description"
+    ],
+    "propertyNames": {
+        "enum": [
+            "id",
+            "version",
+            "name",
+            "description",
+            "disclaimer",
+            "instructions",
+            "capabilities",
+            "behavior_overrides",
+            "conversation_starters",
+            "actions",
+            "$schema"
+        ]
+    },
+    "$defs": {
+        "disclaimer": {
+            "type": "object",
+            "description": "An optional JSON object containing a disclaimer message that, if provided, will be displayed to users at the start of a conversation to satisfy legal or compliance requirements. The object contains a required 'text' string property that MUST NOT be null and MUST contain at least 1 non-whitespace character.",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "description": "A JSON string that contains the disclaimer message. Characters beyond 500 MAY be ignored.",
+                    "minLength": 1
+                }
+            },
+            "required": [
+                "text"
+            ]
+        },
+        "capabilities": {
+            "base-capability": {
+                "type": "object",
+                "description": "Represents a base capability object.",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Required. The name of the capability. Allowed values are WebSearch, CodeInterpreter, OneDriveAndSharePoint, GraphConnectors, TeamsMessages, Dataverse, Email, ScenarioModels, People and GraphicArt.",
+                        "anyOf": [
+                            {
+                                "const": "WebSearch"
+                            },
+                            {
+                                "const": "CodeInterpreter"
+                            },
+                            {
+                                "const": "OneDriveAndSharePoint"
+                            },
+                            {
+                                "const": "GraphConnectors"
+                            },
+                            {
+                                "const": "GraphicArt"
+                            },
+                            {
+                                "const": "TeamsMessages"
+                            },
+                            {
+                                "const": "Dataverse"
+                            },
+                            {
+                                "const": "Email"
+                            },
+                            {
+                                "const": "People"
+                            },
+                            {
+                                "const": "ScenarioModels"
+                            },
+                            {
+                                "const": "Meetings"
+                            }
+                        ]
+                    }
+                },
+                "anyOf": [
+                    {
+                        "$ref": "#/$defs/capabilities/web-search"
+                    },
+                    {
+                        "$ref": "#/$defs/capabilities/onedrive-and-sharepoint"
+                    },
+                    {
+                        "$ref": "#/$defs/capabilities/graph-connectors"
+                    },
+                    {
+                        "$ref": "#/$defs/capabilities/code-interpreter"
+                    },
+                    {
+                        "$ref": "#/$defs/capabilities/graphic-art"
+                    },
+                    {
+                        "$ref": "#/$defs/capabilities/teams-messages"
+                    },
+                    {
+                        "$ref": "#/$defs/capabilities/dataverse"
+                    },
+                    {
+                        "$ref": "#/$defs/capabilities/email"
+                    },
+                    {
+                        "$ref": "#/$defs/capabilities/people"
+                    },
+                    {
+                        "$ref": "#/$defs/capabilities/scenario-models"
+                    },
+                    {
+                        "$ref": "#/$defs/capabilities/meetings"
+                    }
+                ],
+                "required": [
+                    "name"
+                ]
+            },
+            "people": {
+                "type": "object",
+                "description": "Indicates that the DA will be able to search people data in the organization.",
+                "properties": {
+                    "name": {
+                        "const": "People",
+                        "description": "Required. Must be set to People."
+                    }
+                },
+                "propertyNames": {
+                    "enum": [
+                        "name"
+                    ]
+                }
+            },
+            "scenario-models": {
+                "type": "object",
+                "description": "A JSON object whose presence indicates that the DA will be using tenant/task specific models.",
+                "properties": {
+                    "name": {
+                        "const": "ScenarioModels",
+                        "description": "Required. Must be set to the string literal `ScenarioModels`"
+                    },
+                    "models": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "description": "A list of Scenario Model objects denoting supported models",
+                        "items": {
+                            "$ref": "#/$defs/capabilities/scenario-model"
+                        }
+                    }
+                },
+                "propertyNames": {
+                    "enum": [
+                        "name",
+                        "models"
+                    ]
+                },
+                "required": [
+                    "name"
+                ]
+            },
+            "scenario-model": {
+                "type": "object",
+                "description": "An Object representing a scenario model.",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "A unique ID used to identify a Scenario Model"
+                    }
+                },
+                "propertyNames": {
+                    "enum": [
+                        "id"
+                    ]
+                },
+                "required": [
+                    "id"
+                ]
+            },
+            "email": {
+                "type": "object",
+                "description": "A JSON object whose presence indicates that the DA will be able to search within Email Messages in the mailboxes user has access to.",
+                "properties": {
+                    "name": {
+                        "const": "Email",
+                        "description": "Required: Must be set to Email"
+                    },
+                    "folders": {
+                        "type": "array",
+                        "description": "A JSON array of Folder Object. This member can be used to constrain the content accessible to the DA to just the emails present in the folders identified by members of each Folder Object.",
+                        "items": {
+                            "$ref": "#/$defs/capabilities/email-folder"
+                        }
+                    },
+                    "shared_mailbox": {
+                        "type": "string",
+                        "description": "A JSON string that contains SMTP address of the shared mailbox. The presence of this field indicates that the DA constrain its search for relevant emails only to that mailbox. Emails from user's primary mailbox is not searched when this field is present."
+                    }
+                },
+                "propertyNames": {
+                    "enum": [
+                        "name",
+                        "folders",
+                        "shared_mailbox"
+                    ]
+                },
+                "required": [
+                    "name"
+                ]
+            },
+            "email-folder": {
+                "type": "object",
+                "properties": {
+                    "folder_id": {
+                        "type": "string",
+                        "description": "A JSON string that identifies an email folder. This can either be id of the folder or one of the well known names.",
+                        "minLength": 1
+                    }
+                },
+                "propertyNames": {
+                    "enum": [
+                        "folder_id"
+                    ]
+                },
+                "required": [
+                    "folder_id"
+                ]
+            },
+            "dataverse": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "const": "Dataverse",
+                        "description": "Required: Must be set to Dataverse"
+                    },
+                    "knowledge_sources": {
+                        "type": "array",
+                        "description": "An array of Objects that represent the knowledge sources for the Dataverse in the Declarative Agent",
+                        "items": {
+                            "$ref": "#/$defs/capabilities/dataverse-knowledge-source"
+                        }
+                    }
+                },
+                "propertyNames": {
+                    "enum": [
+                        "name",
+                        "knowledge_sources"
+                    ]
+                }
+            },
+            "dataverse-knowledge-source": {
+                "type": "object",
+                "description": "",
+                "properties": {
+                    "host_name": {
+                        "type": "string",
+                        "description": "A unique identifier for the host in Dataverse."
+                    },
+                    "skill": {
+                        "type": "string",
+                        "description": "A unique identifier that defines the configuration for how the copilot agent interacts with Dataverse knowledge."
+                    },
+                    "tables": {
+                        "type": "array",
+                        "description": "An array of table_name objects which contain table names in DataVerse to scope the knowledge of the Declarative Agent",
+                        "items": {
+                            "$ref": "#/$defs/capabilities/dataverse-knowledge-source-table"
+                        }
+                    }
+                },
+                "propertyNames": {
+                    "enum": [
+                        "host_name",
+                        "skill",
+                        "tables"
+                    ]
+                }
+            },
+            "dataverse-knowledge-source-table": {
+                "type": "object",
+                "properties": {
+                    "table_name": {
+                        "type": "string",
+                        "description": "A string to represent the table name."
+                    }
+                },
+                "propertyNames": {
+                    "enum": [
+                        "table_name"
+                    ]
+                }
+            },
+            "teams-messages": {
+                "type": "object",
+                "description": "Indicates that the declarative agent can search through Teams channels, teams, meetings, 1:1 chats and group chats.",
+                "properties": {
+                    "name": {
+                        "const": "TeamsMessages",
+                        "description": "Required. Must be set to TeamsMessages."
+                    },
+                    "urls": {
+                        "type": "array",
+                        "maxItems": 5,
+                        "description": "This member can be used to constrain the content accessible to the DA to just the content identified via the members of each Teams url",
+                        "items": {
+                            "$ref": "#/$defs/capabilities/teams-url"
+                        }
+                    }
+                },
+                "propertyNames": {
+                    "enum": [
+                        "name",
+                        "urls"
+                    ]
+                }
+            },
+            "teams-url": {
+                "type": "object",
+                "description": "Identifies a Teams channel, team or meeting chat",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "description": "A string that contains a well formed, Teams url to a Teams channel, team or meeting chat (join url)"
+                    }
+                },
+                "required": [
+                    "url"
+                ],
+                "propertyNames": {
+                    "enum": [
+                        "url"
+                    ]
+                }
+            },
+            "web-search": {
+                "type": "object",
+                "description": "Indicates that the declarative agent can search the web for grounding information.",
+                "properties": {
+                    "name": {
+                        "const": "WebSearch",
+                        "description": "Required. Must be set to WebSearch."
+                    },
+                    "sites": {
+                        "type": "array",
+                        "minItems": 1,
+                        "maxItems": 4,
+                        "description": "Optional. An array of sites used to constrain the content accessible to the DA to just the content identified via the items of array.",
+                        "items": {
+                            "$ref": "#/$defs/web-search-site"
+                        }
+                    }
+                },
+                "required": [
+                    "name"
+                ],
+                "propertyNames": {
+                    "enum": [
+                        "name",
+                        "sites"
+                    ]
+                }
+            },
+            "code-interpreter": {
+                "type": "object",
+                "description": "Indicates that the declarative agent can generate and execute code.",
+                "properties": {
+                    "name": {
+                        "const": "CodeInterpreter",
+                        "description": "Required. Must be set to CodeInterpreter."
+                    }
+                },
+                "required": [
+                    "name"
+                ],
+                "propertyNames": {
+                    "enum": [
+                        "name"
+                    ]
+                }
+            },
+            "graphic-art": {
+                "type": "object",
+                "description": "Indicates that the declarative agent can images and art based on the text input from the user.",
+                "properties": {
+                    "name": {
+                        "const": "GraphicArt",
+                        "description": "Required. Must be set to GraphicArt."
+                    }
+                },
+                "required": [
+                    "name"
+                ],
+                "propertyNames": {
+                    "enum": [
+                        "name"
+                    ]
+                }
+            },
+            "onedrive-and-sharepoint": {
+                "type": "object",
+                "description": "Indicates that the declarative agent can search a user's SharePoint and OneDrive for grounding information.",
+                "properties": {
+                    "name": {
+                        "const": "OneDriveAndSharePoint",
+                        "description": "Required. Must be set to OneDriveAndSharePoint."
+                    },
+                    "items_by_sharepoint_ids": {
+                        "type": "array",
+                        "minItems": 1,
+                        "description": "Optional. An array of objects that identify SharePoint or OneDrive sources using IDs.",
+                        "items": {
+                            "$ref": "#/$defs/sharepoint-ids"
+                        }
+                    },
+                    "items_by_url": {
+                        "type": "array",
+                        "minItems": 1,
+                        "description": "Optional. An array of objects that identify SharePoint or OneDrive sources by URL.",
+                        "items": {
+                            "$ref": "#/$defs/sharepoint-url"
+                        }
+                    }
+                },
+                "required": [
+                    "name"
+                ],
+                "propertyNames": {
+                    "enum": [
+                        "name",
+                        "items_by_sharepoint_ids",
+                        "items_by_url"
+                    ]
+                }
+            },
+            "graph-connectors": {
+                "type": "object",
+                "description": "Indicates that the declarative agent can search selected Microsoft Graph connectors for grounding information.",
+                "properties": {
+                    "name": {
+                        "const": "GraphConnectors",
+                        "description": "Required. Must be set to GraphConnectors."
+                    },
+                    "connections": {
+                        "type": "array",
+                        "minItems": 1,
+                        "description": "Optional. An array of objects that identify the Microsoft Graph connectors available to the declarative agent",
+                        "items": {
+                            "$ref": "#/$defs/connection"
+                        }
+                    }
+                },
+                "required": [
+                    "name"
+                ],
+                "propertyNames": {
+                    "enum": [
+                        "name",
+                        "connections"
+                    ]
+                }
+            },
+            "meetings": {
+                "type": "object",
+                "description": "Indicates that the DA can search through meetings.",
+                "properties": {
+                    "name": {
+                        "const": "Meetings",
+                        "description": "Required. Must be set to Meetings."
+                    }
+                },
+                "propertyNames": {
+                    "enum": [
+                        "name"
+                    ]
+                }
+            }
+        },
+        "behavior-overrides": {
+            "type": "object",
+            "description": "A JSON object that contains configuration settings that modify the behavior of the DA orchestration.",
+            "properties": {
+                "special_instructions": {
+                    "description": "An object that contains special instructions for the declarative agent.",
+                    "$ref": "#/$defs/special-instructions"
+                },
+                "suggestions": {
+                    "description": "An object that contains suggestions for behavior overrides for the declarative agent.",
+                    "$ref": "#/$defs/suggestions"
+                }
+            },
+            "propertyNames": {
+                "enum": [
+                    "special_instructions",
+                    "suggestions"
+                ]
+            }
+        },
+        "special-instructions": {
+            "type": "object",
+            "description": "A JSON object that contains members used for injecting special instructions into the prompt. The object has a discourage_model_knowledge boolean property. If this property is set to true, the DA will be discouraged from using model knowledge when generating responses. The default value is false",
+            "properties": {
+                "discourage_model_knowledge": {
+                    "type": "boolean",
+                    "description": "A boolean value that indicates whether the declarative agent should be discouraged from using model knowledge when generating responses."
+                }
+            },
+            "propertyNames": {
+                "enum": [
+                    "discourage_model_knowledge"
+                ]
+            }
+        },
+        "suggestions": {
+            "type": "object",
+            "description": "A JSON object that contains configuration settings for the suggestions feature. The object has a required disabled boolean property. If this property is set to true, the suggestions feature will be disabled. The default value is false.",
+            "properties": {
+                "disabled": {
+                    "type": "boolean",
+                    "description": "A boolean value that indicates whether the suggestions feature is disabled. If this property is set to true, the suggestions feature will be disabled. The default value is false."
+                }
+            },
+            "propertyNames": {
+                "enum": [
+                    "disabled"
+                ]
+            }
+        },
+        "web-search-site": {
+            "type": "object",
+            "description": "An object that identifies a site used to constrain the content accessible to the declarative agent.",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": " An absolute URL to a site."
+                }
+            },
+            "required": [
+                "url"
+            ],
+            "propertyNames": {
+                "enum": [
+                    "url"
+                ]
+            }
+        },
+        "conversation-starter": {
+            "type": "object",
+            "description": "Contains hints that are displayed to the user to demonstrate how they can get started using the declarative agent.",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "description": "Required. Localizable. A suggestion that the user can use to obtain the desired result from the DC. It MUST contain at least one nonwhitespace character.",
+                    "pattern": "^(\\[\\[)[a-zA-Z_][a-zA-Z0-9_]*(\\]\\])$|^(?!(.*?\\[\\[.*?|.*?\\]\\].*?)).*$"
+                },
+                "title": {
+                    "type": "string",
+                    "description": "Optional. Localizable. A unique title for the conversation starter. It MUST contain at least one nonwhitespace character.",
+                    "pattern": "^(\\[\\[)[a-zA-Z_][a-zA-Z0-9_]*(\\]\\])$|^(?!(.*?\\[\\[.*?|.*?\\]\\].*?)).*$"
+                }
+            },
+            "required": [
+                "text"
+            ],
+            "propertyNames": {
+                "enum": [
+                    "text",
+                    "title"
+                ]
+            }
+        },
+        "action-object": {
+            "type": "object",
+            "description": "Identifies an API plugin manifest for a plugin used as an action by the declarative agent.",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "Required. Not localizable. A unique identifier for the action. It MAY be represented by a GUID.",
+                    "pattern": "^(?!\\[\\[)(.*?)(?<!\\]\\])$"
+                },
+                "file": {
+                    "type": "string",
+                    "description": "Required. Not localizable. A path to the API plugin manifest for this action.",
+                    "pattern": "^(?!\\[\\[)(.*?)(?<!\\]\\])$"
+                }
+            },
+            "required": [
+                "id",
+                "file"
+            ],
+            "propertyNames": {
+                "enum": [
+                    "id",
+                    "file"
+                ]
+            }
+        },
+        "sharepoint-ids": {
+            "type": "object",
+            "description": "Contains one or more object identifiers that identify a SharePoint or OneDrive resource.",
+            "properties": {
+                "site_id": {
+                    "type": "string",
+                    "description": "Optional. Not localizable. The GUID identifier of a SharePoint or OneDrive site.",
+                    "pattern": "^(?!\\[\\[)(.*?)(?<!\\]\\])$"
+                },
+                "web_id": {
+                    "type": "string",
+                    "description": "Optional. Not localizable. The GUID identifier of a SharePoint or OneDrive web.",
+                    "pattern": "^(?!\\[\\[)(.*?)(?<!\\]\\])$"
+                },
+                "list_id": {
+                    "type": "string",
+                    "description": "Optional. Not localizable. The GUID identifier of a SharePoint or OneDrive list.",
+                    "pattern": "^(?!\\[\\[)(.*?)(?<!\\]\\])$"
+                },
+                "unique_id": {
+                    "type": "string",
+                    "description": "Optional. Not localizable. The GUID identifier of a SharePoint or OneDrive item.",
+                    "pattern": "^(?!\\[\\[)(.*?)(?<!\\]\\])$"
+                },
+                "part_id": {
+                    "type": "string",
+                    "description": "A JSON String that uniquely identifies a part of a SharePoint item. e.g a OneNote page."
+                },
+                "part_type": {
+                    "type": "string",
+                    "description": "A String that qualifies the kind of part that the \"part_id\" refers to. Currently this value can only be equal to the string literal: \"OneNotePart\".",
+                    "enum": [
+                        "OneNotePart"
+                    ]
+                },
+                "search_associated_sites": {
+                    "type": "boolean",
+                    "description": "Boolean value indicating whether to enable searching associated sites. This value is only applicable when the site_id value references a SharePoint HubSite."
+                }
+            },
+            "propertyNames": {
+                "enum": [
+                    "site_id",
+                    "web_id",
+                    "list_id",
+                    "unique_id",
+                    "part_id",
+                    "part_type",
+                    "search_associated_sites"
+                ]
+            },
+            "additionalProperties": false
+        },
+        "sharepoint-url": {
+            "type": "object",
+            "description": "Represents the URL of a SharePoint or OneDrive resource.",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "Optional. Not localizable. An absolute URL to a SharePoint or OneDrive resource.",
+                    "pattern": "^(?!\\[\\[)(.*?)(?<!\\]\\])$"
+                }
+            },
+            "propertyNames": {
+                "enum": [
+                    "url"
+                ]
+            },
+            "additionalProperties": false
+        },
+        "connection": {
+            "type": "object",
+            "description": "Identifies a Microsoft Graph connector.",
+            "properties": {
+                "connection_id": {
+                    "type": "string",
+                    "description": "Required. Not localizable The unique identifier of the Microsoft Graph connector.",
+                    "pattern": "^(?!\\[\\[)(.*?)(?<!\\]\\])$"
+                },
+                "additional_search_terms": {
+                    "type": "string",
+                    "description": "KQL based string containing the query filter"
+                },
+                "items_by_external_url": {
+                    "type": "array",
+                    "description": "A list of objects to store urls for external items.",
+                    "items": {
+                        "$ref": "#/$defs/item-by-external-url"
+                    }
+                },
+                "items_by_external_id": {
+                    "type": "array",
+                    "description": "A list of objects to store identifiers for external items",
+                    "items": {
+                        "$ref": "#/$defs/item-by-external-id"
+                    }
+                },
+                "items_by_path": {
+                    "type": "array",
+                    "description": "A list of objects to store the container paths to items within a connection",
+                    "items": {
+                        "$ref": "#/$defs/item-by-path"
+                    }
+                },
+                "items_by_container_name": {
+                    "type": "array",
+                    "description": "A list of objects to store containers names",
+                    "uniqueItems": true,
+                    "items": {
+                        "$ref": "#/$defs/item-by-container-name"
+                    }
+                },
+                "items_by_container_url": {
+                    "type": "array",
+                    "description": "A list of objects to store urls of containers",
+                    "uniqueItems": true,
+                    "items": {
+                        "$ref": "#/$defs/item-by-container-url"
+                    }
+                }
+            },
+            "required": [
+                "connection_id"
+            ],
+            "propertyNames": {
+                "enum": [
+                    "connection_id",
+                    "additional_search_terms",
+                    "items_by_external_url",
+                    "items_by_external_id",
+                    "items_by_path",
+                    "items_by_container_name",
+                    "items_by_container_url"
+                ]
+            }
+        },
+        "item-by-external-url": {
+            "type": "object",
+            "description": "Identifies an item by its external URL.",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "Url for external graph connector item."
+                }
+            },
+            "required": [
+                "url"
+            ],
+            "propertyNames": {
+                "enum": [
+                    "url"
+                ]
+            }
+        },
+        "item-by-external-id": {
+            "type": "object",
+            "description": "Identifies an item by its external ID.",
+            "properties": {
+                "item_id": {
+                    "type": "string",
+                    "description": "A unique identifier for an external item."
+                }
+            },
+            "required": [
+                "item_id"
+            ],
+            "propertyNames": {
+                "enum": [
+                    "item_id"
+                ]
+            }
+        },
+        "item-by-path": {
+            "type": "object",
+            "description": "Identifies an item by its path.",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "A container path to an external item"
+                }
+            },
+            "required": [
+                "path"
+            ],
+            "propertyNames": {
+                "enum": [
+                    "path"
+                ]
+            }
+        },
+        "item-by-container-name": {
+            "type": "object",
+            "description": "Identifies an item by its container name.",
+            "properties": {
+                "container_name": {
+                    "type": "string",
+                    "description": "A unique identifier for a container name"
+                }
+            },
+            "required": [
+                "container_name"
+            ],
+            "propertyNames": {
+                "enum": [
+                    "container_name"
+                ]
+            }
+        },
+        "item-by-container-url": {
+            "type": "object",
+            "description": "Identifies an item by its container URL.",
+            "properties": {
+                "container_url": {
+                    "type": "string",
+                    "description": "Url for external graph connector item container"
+                }
+            },
+            "required": [
+                "container_url"
+            ],
+            "propertyNames": {
+                "enum": [
+                    "container_url"
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the JSON Schema for Copilot Declarative Agent Manifest v1.5.

##### Additions:
- Adds Meetings to `capabilities` array.

##### Removals:
N/A

##### Modifications:
N/A

### Validation
Passes validation when the correct meetings capability name is used.
<img width="1240" height="310" alt="image" src="https://github.com/user-attachments/assets/c3944e72-f4a5-4d8d-a7ea-826348ed22ef" />

Correctly flags a warning when the wrong meetings capability name is used:
<img width="1225" height="315" alt="image" src="https://github.com/user-attachments/assets/d597301d-0ee7-4aa1-befe-915d92df6df4" />


