### PR TITLE
fix: Update DA 1.6 JSON Schema

### DIFF
--- a/copilot/declarative-agent/v1.6/schema.json
+++ b/copilot/declarative-agent/v1.6/schema.json
@@ -61,8 +61,8 @@
         },
         "conversation_starters": {
             "type": "array",
-            "description": "Optional. A list of examples of questions that the declarative agent can answer. There MUST NOT be more than six objects in the array.",
-            "maxItems": 6,
+            "description": "Optional. A list of examples of questions that the declarative agent can answer. There MUST NOT be more than twelve objects in the array.",
+            "maxItems": 12,
             "minItems": 1,
             "items": {
                 "$ref": "#/$defs/conversation-starter"
@@ -235,7 +235,7 @@
                     "embedded_resource_snapshot_id": {
                         "type": "string",
                         "description": "A JSON string identifier provisioned by a an external file container storage service that can be used to locate the embedded knowledge files.",
-                        "pattern": "^(?!\\[\\[)(.*?)(?<!\\\\]\\\\])$"
+                        "pattern": "^(?!\\[\\[)(.*?)(?<!\\]\\])$"
                     },
                     "files": {
                         "type": "array",
@@ -286,7 +286,7 @@
                         "type": "string",
                         "description": "A JSON string that contains the file relative path for the embedded file. It is a required member.",
                         "minLength": 1,
-                        "pattern": "^(?!\\[\\[)(.*?)(?<!\\\\]\\\\])$"
+                        "pattern": "^(?!\\[\\[)(.*?)(?<!\\]\\])$"
                     }
                 },
                 "required": [


### PR DESCRIPTION
This PR updates the DA 1.6 JSON Schema by proposing the following changes:
- Increases conversation_starters limit from 6 to 12.
- Updates the `embedded_resource_snapshot_id` and embedded knowledge `file` regex by removing double-escaped brackets `\\\\]\\\\]` which created "lone quantifier brackets" that are invalid in regex.

Fixes https://github.com/microsoft/Microsoft.Plugins.Manifest/issues/686
Fixes https://github.com/microsoft/Microsoft.Plugins.Manifest/issues/685