### PR TITLE
Fixes to Nov 2025 vDevPreview schema

### DIFF
--- a/teams/vDevPreview/MicrosoftTeams.schema.json
+++ b/teams/vDevPreview/MicrosoftTeams.schema.json
@@ -2362,7 +2362,7 @@
                 "description": "Must be either scalar (a non-array value) or matrix (a 2-dimensional array)."
               },
               "optional": {
-                "type": "boolean",
+                "type": ["boolean", "null"],
                 "default": false,
                 "description": "If true, the parameter is optional."
               },


### PR DESCRIPTION
Fixes needed to unblock generated reference docs publish:

- Update links in descriptions to point to public API Plugin manifest reference on Learn
- Update remoteMCPServer url type to httpsUrl