### PR TITLE
Reinstate secureHttpUrl for mcpServerUrl

### DIFF
--- a/teams/vDevPreview/MicrosoftTeams.schema.json
+++ b/teams/vDevPreview/MicrosoftTeams.schema.json
@@ -1661,7 +1661,7 @@
                         "additionalProperties": false,
                         "properties": {
                         "mcpServerUrl": {
-                            "$ref": "#/definitions/httpsUrl",
+                            "$ref": "#/definitions/secureHttpUrl",
                             "description": "The URL of the remote MCP Server."
                         },
                         "mcpToolDescription": {


### PR DESCRIPTION
It was accidentally regressed when this [stale commit](https://github.com/microsoft/json-schemas/commit/5d828b46c53a6982cc2eb9e9fe01e7475e884864) got merged (in my [PR with otherwise relevant fixes](https://github.com/microsoft/json-schemas/pull/476)). 

The original commit was a workaround for docs generation because the definition for `secureHttpUrl` didn't yet exist in the schema.