### PR TITLE
Fabric MirroredCatalog Item: Remove `AzureMonitorMirroredCatalog` from SourceType enum

### DIFF
--- a/fabric/item/mirroredCatalog/definition/mirroredCatalogDefinition/1.0.0/schema.json
+++ b/fabric/item/mirroredCatalog/definition/mirroredCatalogDefinition/1.0.0/schema.json
@@ -60,8 +60,7 @@
       "title": "Source Type",
       "description": "The type of the source catalog provider. Additional source types may be added over time.",
       "enum": [
-        "DremioIcebergCatalog",
-        "AzureMonitorMirroredCatalog"
+        "DremioIcebergCatalog"
       ]
     },
     "SourceTypeProperties": {


### PR DESCRIPTION
Remove `AzureMonitorMirroredCatalog` from SourceType enum - only `DremioIcebergCatalog` for now