### PR TITLE
Add JSON schema for PolicySet definition

### DIFF
--- a/fabric/item/policySet/definition/1.0.0/schema.json
+++ b/fabric/item/policySet/definition/1.0.0/schema.json
@@ -1,0 +1,147 @@
+{
+  "$id": "https://developer.microsoft.com/json-schemas/fabric/item/policySet/definition/1.0.0/schema.json",
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "PolicySet",
+  "type": "object",
+  "properties": {
+    "properties": {
+      "type": "object",
+      "properties": {
+        "scope": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "type"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "scope"
+      ],
+      "additionalProperties": false
+    },
+    "policyRules": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/policyRule"
+      }
+    }
+  },
+  "required": [
+    "properties",
+    "policyRules"
+  ],
+  "additionalProperties": false,
+  "definitions": {
+    "policyRule": {
+      "type": "object",
+      "properties": {
+        "displayName": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "policy": {
+          "type": "string"
+        },
+        "conditions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/condition"
+          }
+        },
+        "then": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/effect"
+          }
+        }
+      },
+      "required": [
+        "displayName",
+        "description",
+        "policy",
+        "conditions",
+        "then"
+      ],
+      "additionalProperties": false
+    },
+    "condition": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "targetProperty": {
+          "type": "string"
+        },
+        "predicate": {
+          "$ref": "#/definitions/predicate"
+        }
+      },
+      "required": [
+        "type",
+        "targetProperty",
+        "predicate"
+      ],
+      "additionalProperties": false
+    },
+    "predicate": {
+      "type": "object",
+      "properties": {
+        "operator": {
+          "type": "string"
+        },
+        "values": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "value": {
+          "type": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "operator"
+      ],
+      "oneOf": [
+        {
+          "required": [
+            "values"
+          ]
+        },
+        {
+          "required": [
+            "value"
+          ]
+        }
+      ],
+      "additionalProperties": false
+    },
+    "effect": {
+      "type": "object",
+      "properties": {
+        "effect": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "effect"
+      ],
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
This JSON schema defines the structure for a PolicySet, including properties, required fields, and definitions for policy rules, conditions, predicates, and effects.