### PR TITLE
Add `AzureMonitorMirroredCatalog` to MirroredCatalog `SourceType` enum

### DIFF
--- a/fabric/item/mirroredCatalog/definition/mirroredCatalogDefinition/1.0.0/schema.json
+++ b/fabric/item/mirroredCatalog/definition/mirroredCatalogDefinition/1.0.0/schema.json
@@ -60,7 +60,8 @@
       "title": "Source Type",
       "description": "The type of the source catalog provider. Additional source types may be added over time.",
       "enum": [
-        "DremioIcebergCatalog"
+        "DremioIcebergCatalog",
+        "AzureMonitorMirroredCatalog"
       ]
     },
     "SourceTypeProperties": {


### PR DESCRIPTION
Adds the AzureMonitorMirroredCatalog source type to the mirroredCatalogDefinition 1.0.0 SourceType enum for the Azure Monitor provider going to Public Preview. Additive, backward-compatible change (the schema already notes additional source types may be added over time); AzMon uses the same connectionId + scope typeProperties as Dremio.