### PR TITLE
chore: Update DA Schema v1.8

### DIFF
--- a/copilot/declarative-agent/v1.8/schema.json
+++ b/copilot/declarative-agent/v1.8/schema.json
@@ -1,0 +1,1306 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$comment": "This schema describes the constraints of a declarative agent for third party developers to be deployed to Microsoft 365 Copilot",
+    "type": "object",
+    "title": "Declarative agent manifest object",
+    "description": "The root of the declarative agent manifest document is a JSON object that contains members that describe the declarative agent.",
+    "properties": {
+        "version": {
+            "description": "Required. Not localizable. The version of the schema this manifest is using.",
+            "type": "string",
+            "const": "v1.8"
+        },
+        "id": {
+            "description": "Optional. Not localizable.",
+            "type": "string",
+            "pattern": "^(?!\\[\\[)(.*?)(?<!\\]\\])$"
+        },
+        "name": {
+            "type": "string",
+            "description": "Required. Localizable. The name of the declarative agent. It MUST contain at least one nonwhitespace character and MUST be 100 characters or less.",
+            "minLength": 1,
+            "maxLength": 100,
+            "pattern": "^(\\[\\[)[a-zA-Z_][a-zA-Z0-9_]*(\\]\\])$|^(?!(.*?\\[\\[.*?|.*?\\]\\].*?)).*$"
+        },
+        "description": {
+            "type": "string",
+            "description": "Required. Localizable. The description of the declarative agent. It MUST contain at least one nonwhitespace character and MUST be 1,000 characters or less.",
+            "minLength": 1,
+            "maxLength": 1000,
+            "pattern": "^(\\[\\[)[a-zA-Z_][a-zA-Z0-9_]*(\\]\\])$|^(?!(.*?\\[\\[.*?|.*?\\]\\].*?)).*$"
+        },
+        "disclaimer": {
+            "$ref": "#/$defs/disclaimer"
+        },
+        "instructions": {
+            "type": "string",
+            "description": "Optional. Not localizable. The detailed instructions or guidelines on how the declarative agent should behave, its functions, and any behaviors to avoid. It MUST contain at least one nonwhitespace character and MUST be 8,000 characters or less.",
+            "minLength": 1,
+            "maxLength": 8000,
+            "pattern": "^(?!\\[\\[)((.|\\n|\\r)*?)(?<!\\]\\])$"
+        },
+        "behavior_overrides": {
+            "description": "Optional. A JSON object that contains configuration settings that modify the behavior of the DA orchestration.",
+            "$ref": "#/$defs/behavior-overrides"
+        },
+        "capabilities": {
+            "type": "array",
+            "description": "Optional. Contains an array of objects that define capabilities of the declarative agent.",
+            "uniqueItems": true,
+            "items": {
+                "anyOf": [
+                    {
+                        "$ref": "#/$defs/capabilities/base-capability"
+                    }
+                ]
+            }
+        },
+        "conversation_starters": {
+            "type": "array",
+            "description": "Optional. A list of examples of questions that the declarative agent can answer. There MUST NOT be more than 12 objects in the array.",
+            "maxItems": 12,
+            "minItems": 1,
+            "items": {
+                "$ref": "#/$defs/conversation-starter"
+            }
+        },
+        "actions": {
+            "type": "array",
+            "description": "Optional. A list of objects that identify API plugins that provide actions accessible to the declarative agent.",
+            "minItems": 1,
+            "maxItems": 10,
+            "items": {
+                "oneOf": [
+                    {
+                        "$ref": "#/$defs/action-object"
+                    }
+                ]
+            }
+        },
+        "user_overrides": {
+            "type": "array",
+            "description": "Optional. A list of user override objects. This optional member allows DA authors to specify which capabilities can be dynamically adjusted by the user of the DA.",
+            "items": {
+                "$ref": "#/$defs/user-override-object"
+            }
+        },
+        "editorial_answers": {
+            "description": "Optional. A JSON object that contains predefined question-answer pairs that the DA can use to respond to user queries based on semantic similarity.",
+            "$ref": "#/$defs/editorial-answers-object"
+        },
+        "worker_agents": {
+            "type": "array",
+            "description": "Optional. A list of worker agent objects that identify declarative agents to act as worker agents.",
+            "items": {
+                "$ref": "#/$defs/worker-agent-object"
+            }
+        },
+        "sensitivity_label": {
+            "description": "Optional. A JSON object that specifies the sensitivity label for the DA.",
+            "$ref": "#/$defs/sensitivity-label-object"
+        }
+    },
+    "required": [
+        "version",
+        "name",
+        "description"
+    ],
+    "propertyNames": {
+        "enum": [
+            "id",
+            "version",
+            "name",
+            "description",
+            "disclaimer",
+            "instructions",
+            "capabilities",
+            "behavior_overrides",
+            "conversation_starters",
+            "actions",
+            "user_overrides",
+            "editorial_answers",
+            "worker_agents",
+            "$schema",
+            "sensitivity_label"
+        ]
+    },
+    "$defs": {
+        "disclaimer": {
+            "type": "object",
+            "description": "An optional JSON object containing a disclaimer message that, if provided, will be displayed to users at the start of a conversation to satisfy legal or compliance requirements. The object contains a required 'text' string property that MUST NOT be null and MUST contain at least 1 non-whitespace character.",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "description": "A JSON string that contains the disclaimer message. Characters beyond 500 MAY be ignored.",
+                    "minLength": 1,
+                    "maxLength": 500
+                }
+            },
+            "required": [
+                "text"
+            ]
+        },
+        "user-override-object": {
+            "type": "object",
+            "description": "A JSON object that allows the DA author to specify the path of a capability that can be modified and a set of allowed_actions for those capabilities.",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "A JSON string that contains a JSONPath expression identifying the capability or configuration element that users can modify."
+                },
+                "allowed_actions": {
+                    "type": "array",
+                    "description": "A JSON array of strings that specifies what actions can be taken for the specified path. The only supported action is 'remove'.",
+                    "items": {
+                        "type": "string",
+                        "enum": [
+                            "remove"
+                        ]
+                    }
+                }
+            },
+            "required": [
+                "path",
+                "allowed_actions"
+            ],
+            "propertyNames": {
+                "enum": [
+                    "path",
+                    "allowed_actions"
+                ]
+            }
+        },
+        "editorial-answers-object": {
+            "type": "object",
+            "description": "A JSON object that contains either an answers array or url to define predefined question-answer pairs for semantic matching and responses.",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "A JSON string containing a URL that locates a document containing the editorial answers configuration."
+                },
+                "answers": {
+                    "type": "array",
+                    "description": "A JSON array that contains a list of answer objects. There MUST NOT be more than 300 objects in this array.",
+                    "maxItems": 300,
+                    "items": {
+                        "$ref": "#/$defs/answer-object"
+                    }
+                }
+            },
+            "oneOf": [
+                {
+                    "required": [
+                        "url"
+                    ]
+                },
+                {
+                    "required": [
+                        "answers"
+                    ]
+                }
+            ],
+            "propertyNames": {
+                "enum": [
+                    "url",
+                    "answers"
+                ]
+            }
+        },
+        "answer-object": {
+            "type": "object",
+            "description": "A JSON object containing a predefined question-answer pair.",
+            "properties": {
+                "question": {
+                    "type": "string",
+                    "description": "A JSON string containing the predefined question that will be used for semantic similarity matching against user queries.",
+                    "minLength": 1
+                },
+                "answer": {
+                    "type": "string",
+                    "description": "A JSON string containing the predefined answer that will be returned when the user query matches the question above the similarity threshold.",
+                    "minLength": 1
+                },
+                "similarity_thresholds": {
+                    "$ref": "#/$defs/similarity-thresholds-object"
+                }
+            },
+            "required": [
+                "question",
+                "answer"
+            ],
+            "propertyNames": {
+                "enum": [
+                    "question",
+                    "answer",
+                    "similarity_thresholds"
+                ]
+            }
+        },
+        "similarity-thresholds-object": {
+            "type": "object",
+            "description": "A JSON object that contains the minimum and maximum similarity threshold values for semantic matching.",
+            "properties": {
+                "min": {
+                    "type": "number",
+                    "description": "A JSON number that represents the minimum similarity threshold. The value MUST be a number between 0 and 10 inclusive.",
+                    "minimum": 0,
+                    "maximum": 10
+                },
+                "max": {
+                    "type": "number",
+                    "description": "A JSON number that represents the maximum similarity threshold. The value MUST be a number between 0 and 10 inclusive.",
+                    "minimum": 0,
+                    "maximum": 10
+                }
+            },
+            "required": [
+                "min",
+                "max"
+            ],
+            "propertyNames": {
+                "enum": [
+                    "min",
+                    "max"
+                ]
+            }
+        },
+        "worker-agent-object": {
+            "type": "object",
+            "description": "A JSON object used to identify a declarative agent to act as a worker agent.",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "A JSON string that is a unique identifier for a Declarative Agent."
+                },
+                "file": {
+                    "type": "string",
+                    "description": "A JSON string that is a relative file path to a Declarative Agent manifest for the worker agent."
+                }
+            },
+            "oneOf": [
+                {
+                    "required": [
+                        "id"
+                    ]
+                },
+                {
+                    "required": [
+                        "file"
+                    ]
+                }
+            ],
+            "propertyNames": {
+                "enum": [
+                    "id",
+                    "file"
+                ]
+            }
+        },
+        "capabilities": {
+            "base-capability": {
+                "type": "object",
+                "description": "Represents a base capability object.",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Required. The name of the capability. Allowed values are WebSearch, GraphicArt, CodeInterpreter, OneDriveAndSharePoint, GraphConnectors, TeamsMessages, EmbeddedKnowledge, Email, EmailActions, People, Meetings, MeetingActions, Dataverse, and ScenarioModels.",
+                        "anyOf": [
+                            {
+                                "const": "WebSearch"
+                            },
+                            {
+                                "const": "GraphicArt"
+                            },
+                            {
+                                "const": "CodeInterpreter"
+                            },
+                            {
+                                "const": "OneDriveAndSharePoint"
+                            },
+                            {
+                                "const": "GraphConnectors"
+                            },
+                            {
+                                "const": "TeamsMessages"
+                            },
+                            {
+                                "const": "EmbeddedKnowledge"
+                            },
+                            {
+                                "const": "Email"
+                            },
+                            {
+                                "const": "EmailActions"
+                            },
+                            {
+                                "const": "People"
+                            },
+                            {
+                                "const": "Meetings"
+                            },
+                            {
+                                "const": "MeetingActions"
+                            },
+                            {
+                                "const": "Dataverse"
+                            },
+                            {
+                                "const": "ScenarioModels"
+                            }
+                        ]
+                    }
+                },
+                "anyOf": [
+                    {
+                        "$ref": "#/$defs/capabilities/web-search"
+                    },
+                    {
+                        "$ref": "#/$defs/capabilities/onedrive-and-sharepoint"
+                    },
+                    {
+                        "$ref": "#/$defs/capabilities/graph-connectors"
+                    },
+                    {
+                        "$ref": "#/$defs/capabilities/code-interpreter"
+                    },
+                    {
+                        "$ref": "#/$defs/capabilities/graphic-art"
+                    },
+                    {
+                        "$ref": "#/$defs/capabilities/teams-messages"
+                    },
+                    {
+                        "$ref": "#/$defs/capabilities/dataverse"
+                    },
+                    {
+                        "$ref": "#/$defs/capabilities/email"
+                    },
+                    {
+                        "$ref": "#/$defs/capabilities/people"
+                    },
+                    {
+                        "$ref": "#/$defs/capabilities/scenario-models"
+                    },
+                    {
+                        "$ref": "#/$defs/capabilities/meetings"
+                    },
+                    {
+                        "$ref": "#/$defs/capabilities/meeting-actions"
+                    },
+                    {
+                        "$ref": "#/$defs/capabilities/embedded-knowledge"
+                    },
+                    {
+                        "$ref": "#/$defs/capabilities/email-actions"
+                    }
+                ],
+                "required": [
+                    "name"
+                ]
+            },
+            "people": {
+                "type": "object",
+                "description": "Indicates that the DA will be able to search people data in the organization.",
+                "properties": {
+                    "name": {
+                        "const": "People",
+                        "description": "Required. Must be set to People."
+                    },
+                    "include_related_content": {
+                        "type": "boolean",
+                        "description": "A JSON boolean that indicates whether to include related content when searching people data. When set to true, the DA will include related documents, emails, and Teams messages."
+                    }
+                },
+                "propertyNames": {
+                    "enum": [
+                        "name",
+                        "include_related_content"
+                    ]
+                }
+            },
+            "scenario-models": {
+                "type": "object",
+                "description": "A JSON object whose presence indicates that the DA will be using tenant/task specific models.",
+                "properties": {
+                    "name": {
+                        "const": "ScenarioModels",
+                        "description": "Required. Must be set to the string literal `ScenarioModels`"
+                    },
+                    "models": {
+                        "type": "array",
+                        "uniqueItems": true,
+                        "description": "A list of Scenario Model objects denoting supported models",
+                        "items": {
+                            "$ref": "#/$defs/capabilities/scenario-model"
+                        }
+                    }
+                },
+                "propertyNames": {
+                    "enum": [
+                        "name",
+                        "models"
+                    ]
+                },
+                "required": [
+                    "name"
+                ]
+            },
+            "scenario-model": {
+                "type": "object",
+                "description": "An Object representing a scenario model.",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "description": "A unique ID used to identify a Scenario Model"
+                    }
+                },
+                "propertyNames": {
+                    "enum": [
+                        "id"
+                    ]
+                },
+                "required": [
+                    "id"
+                ]
+            },
+            "email": {
+                "type": "object",
+                "description": "A JSON object whose presence indicates that the DA will be able to search within Email Messages in the mailboxes user has access to.",
+                "properties": {
+                    "name": {
+                        "const": "Email",
+                        "description": "Required: Must be set to Email"
+                    },
+                    "folders": {
+                        "type": "array",
+                        "description": "A JSON array of Folder Object. This member can be used to constrain the content accessible to the DA to just the emails present in the folders identified by members of each Folder Object.",
+                        "items": {
+                            "$ref": "#/$defs/capabilities/email-folder"
+                        }
+                    },
+                    "shared_mailbox": {
+                        "type": "string",
+                        "description": "A JSON string that contains SMTP address of the shared mailbox. The presence of this field indicates that the DA constrain its search for relevant emails only to that mailbox. Emails from user's primary mailbox is not searched when this field is present."
+                    },
+                    "group_mailboxes": {
+                        "type": "array",
+                        "description": "A JSON array of strings containing SMTP addresses of group mailboxes. The presence of this field indicates that the DA can search for relevant emails in the specified group mailboxes. A maximum of 25 mailboxes are supported.",
+                        "maxItems": 25,
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "propertyNames": {
+                    "enum": [
+                        "name",
+                        "folders",
+                        "shared_mailbox",
+                        "group_mailboxes"
+                    ]
+                },
+                "required": [
+                    "name"
+                ]
+            },
+            "email-folder": {
+                "type": "object",
+                "properties": {
+                    "folder_id": {
+                        "type": "string",
+                        "description": "A JSON string that identifies an email folder. This can either be id of the folder or one of the well known names.",
+                        "minLength": 1
+                    }
+                },
+                "propertyNames": {
+                    "enum": [
+                        "folder_id"
+                    ]
+                },
+                "required": [
+                    "folder_id"
+                ]
+            },
+            "dataverse": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "const": "Dataverse",
+                        "description": "Required: Must be set to Dataverse"
+                    },
+                    "knowledge_sources": {
+                        "type": "array",
+                        "description": "An array of Objects that represent the knowledge sources for the Dataverse in the Declarative Agent",
+                        "items": {
+                            "$ref": "#/$defs/capabilities/dataverse-knowledge-source"
+                        }
+                    }
+                },
+                "propertyNames": {
+                    "enum": [
+                        "name",
+                        "knowledge_sources"
+                    ]
+                }
+            },
+            "dataverse-knowledge-source": {
+                "type": "object",
+                "description": "",
+                "properties": {
+                    "host_name": {
+                        "type": "string",
+                        "description": "A unique identifier for the host in Dataverse."
+                    },
+                    "skill": {
+                        "type": "string",
+                        "description": "A unique identifier that defines the configuration for how the copilot agent interacts with Dataverse knowledge."
+                    },
+                    "tables": {
+                        "type": "array",
+                        "description": "An array of table_name objects which contain table names in DataVerse to scope the knowledge of the Declarative Agent",
+                        "items": {
+                            "$ref": "#/$defs/capabilities/dataverse-knowledge-source-table"
+                        }
+                    }
+                },
+                "propertyNames": {
+                    "enum": [
+                        "host_name",
+                        "skill",
+                        "tables"
+                    ]
+                }
+            },
+            "dataverse-knowledge-source-table": {
+                "type": "object",
+                "properties": {
+                    "table_name": {
+                        "type": "string",
+                        "description": "A string to represent the table name."
+                    }
+                },
+                "propertyNames": {
+                    "enum": [
+                        "table_name"
+                    ]
+                }
+            },
+            "teams-messages": {
+                "type": "object",
+                "description": "Indicates that the declarative agent can search through Teams channels, teams, meetings, 1:1 chats and group chats.",
+                "properties": {
+                    "name": {
+                        "const": "TeamsMessages",
+                        "description": "Required. Must be set to TeamsMessages."
+                    },
+                    "urls": {
+                        "type": "array",
+                        "maxItems": 5,
+                        "description": "This member can be used to constrain the content accessible to the DA to just the content identified via the members of each Teams url",
+                        "items": {
+                            "$ref": "#/$defs/capabilities/teams-url"
+                        }
+                    }
+                },
+                "propertyNames": {
+                    "enum": [
+                        "name",
+                        "urls"
+                    ]
+                }
+            },
+            "teams-url": {
+                "type": "object",
+                "description": "Identifies a Teams channel, team or meeting chat",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "description": "A string that contains a well formed, Teams url to a Teams channel, team or meeting chat (join url)"
+                    }
+                },
+                "required": [
+                    "url"
+                ],
+                "propertyNames": {
+                    "enum": [
+                        "url"
+                    ]
+                }
+            },
+            "web-search": {
+                "type": "object",
+                "description": "Indicates that the declarative agent can search the web for grounding information.",
+                "properties": {
+                    "name": {
+                        "const": "WebSearch",
+                        "description": "Required. Must be set to WebSearch."
+                    },
+                    "sites": {
+                        "type": "array",
+                        "minItems": 1,
+                        "maxItems": 4,
+                        "description": "Optional. An array of sites used to constrain the content accessible to the DA to just the content identified via the items of array.",
+                        "items": {
+                            "$ref": "#/$defs/web-search-site"
+                        }
+                    }
+                },
+                "required": [
+                    "name"
+                ],
+                "propertyNames": {
+                    "enum": [
+                        "name",
+                        "sites"
+                    ]
+                }
+            },
+            "code-interpreter": {
+                "type": "object",
+                "description": "Indicates that the declarative agent can generate and execute code.",
+                "properties": {
+                    "name": {
+                        "const": "CodeInterpreter",
+                        "description": "Required. Must be set to CodeInterpreter."
+                    }
+                },
+                "required": [
+                    "name"
+                ],
+                "propertyNames": {
+                    "enum": [
+                        "name"
+                    ]
+                }
+            },
+            "graphic-art": {
+                "type": "object",
+                "description": "Indicates that the declarative agent can images and art based on the text input from the user.",
+                "properties": {
+                    "name": {
+                        "const": "GraphicArt",
+                        "description": "Required. Must be set to GraphicArt."
+                    }
+                },
+                "required": [
+                    "name"
+                ],
+                "propertyNames": {
+                    "enum": [
+                        "name"
+                    ]
+                }
+            },
+            "onedrive-and-sharepoint": {
+                "type": "object",
+                "description": "Indicates that the declarative agent can search a user's SharePoint and OneDrive for grounding information.",
+                "properties": {
+                    "name": {
+                        "const": "OneDriveAndSharePoint",
+                        "description": "Required. Must be set to OneDriveAndSharePoint."
+                    },
+                    "items_by_sharepoint_ids": {
+                        "type": "array",
+                        "minItems": 1,
+                        "description": "Optional. An array of objects that identify SharePoint or OneDrive sources using IDs.",
+                        "items": {
+                            "$ref": "#/$defs/sharepoint-ids"
+                        }
+                    },
+                    "items_by_url": {
+                        "type": "array",
+                        "minItems": 1,
+                        "description": "Optional. An array of objects that identify SharePoint or OneDrive sources by URL.",
+                        "items": {
+                            "$ref": "#/$defs/sharepoint-url"
+                        }
+                    }
+                },
+                "required": [
+                    "name"
+                ],
+                "propertyNames": {
+                    "enum": [
+                        "name",
+                        "items_by_sharepoint_ids",
+                        "items_by_url"
+                    ]
+                }
+            },
+            "graph-connectors": {
+                "type": "object",
+                "description": "Indicates that the declarative agent can search selected Microsoft Graph connectors for grounding information.",
+                "properties": {
+                    "name": {
+                        "const": "GraphConnectors",
+                        "description": "Required. Must be set to GraphConnectors."
+                    },
+                    "connections": {
+                        "type": "array",
+                        "minItems": 1,
+                        "description": "Optional. An array of objects that identify the Microsoft Graph connectors available to the declarative agent",
+                        "items": {
+                            "$ref": "#/$defs/connection"
+                        }
+                    }
+                },
+                "required": [
+                    "name"
+                ],
+                "propertyNames": {
+                    "enum": [
+                        "name",
+                        "connections"
+                    ]
+                }
+            },
+            "meetings": {
+                "type": "object",
+                "description": "Indicates that the DA can search through meetings.",
+                "properties": {
+                    "name": {
+                        "const": "Meetings",
+                        "description": "Required. Must be set to Meetings."
+                    },
+                    "items_by_id": {
+                        "type": "array",
+                        "description": "Optional. An array of objects that identify meetings by their ICalUID.",
+                        "items": {
+                            "$ref": "#/$defs/meeting-identifier"
+                        }
+                    }
+                },
+                "propertyNames": {
+                    "enum": [
+                        "name",
+                        "items_by_id"
+                    ]
+                }
+            },
+            "email-actions": {
+                "type": "object",
+                "description": "A JSON object whose presence indicates that the DA will be able to perform write operations on email in the mailboxes the user has access to.",
+                "properties": {
+                    "name": {
+                        "const": "EmailActions",
+                        "description": "Required. Must be set to EmailActions."
+                    }
+                },
+                "required": [
+                    "name"
+                ],
+                "propertyNames": {
+                    "enum": [
+                        "name"
+                    ]
+                }
+            },
+            "meeting-actions": {
+                "type": "object",
+                "description": "A JSON object whose presence indicates that the DA will be able to perform meeting and calendar actions, such as scheduling events, creating time-finding polls, or surfacing time insights.",
+                "properties": {
+                    "name": {
+                        "const": "MeetingActions",
+                        "description": "Required. Must be set to MeetingActions."
+                    }
+                },
+                "required": [
+                    "name"
+                ],
+                "propertyNames": {
+                    "enum": [
+                        "name"
+                    ]
+                }
+            },
+            "embedded-knowledge": {
+                "type": "object",
+                "description": "Indicates that the DA will be able to use files locally in the app package as knowledge.",
+                "properties": {
+                    "name": {
+                        "const": "EmbeddedKnowledge",
+                        "description": "Required. Must be set to EmbeddedKnowledge."
+                    },
+                    "embedded_resource_snapshot_id": {
+                        "type": "string",
+                        "description": "A JSON string identifier provisioned by an external file container storage service that can be used to locate the embedded knowledge files."
+                    },
+                    "files": {
+                        "type": "array",
+                        "description": "A JSON array of file objects. List of objects identifying files that contain knowledge the Agent can use for grounding. Maximum 10 files, max 1MB each.",
+                        "maxItems": 10,
+                        "items": {
+                            "$ref": "#/$defs/embedded-knowledge-file"
+                        }
+                    }
+                },
+                "required": [
+                    "name"
+                ],
+                "oneOf": [
+                    {
+                        "required": [
+                            "embedded_resource_snapshot_id"
+                        ]
+                    },
+                    {
+                        "required": [
+                            "files"
+                        ]
+                    }
+                ],
+                "propertyNames": {
+                    "enum": [
+                        "name",
+                        "embedded_resource_snapshot_id",
+                        "files"
+                    ]
+                }
+            }
+        },
+        "embedded-knowledge-file": {
+            "type": "object",
+            "description": "A JSON object that identifies a file via the relative path.",
+            "properties": {
+                "file": {
+                    "type": "string",
+                    "description": "A JSON string that contains the file relative path for the embedded file."
+                }
+            },
+            "required": [
+                "file"
+            ],
+            "propertyNames": {
+                "enum": [
+                    "file"
+                ]
+            }
+        },
+        "meeting-identifier": {
+            "type": "object",
+            "description": "A JSON object that identifies a meeting by its ICalUID.",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "A JSON string that contains the ICalUID of a specific meeting."
+                },
+                "is_series": {
+                    "type": "boolean",
+                    "description": "A JSON boolean that indicates whether the meeting is a series."
+                }
+            },
+            "required": [
+                "id",
+                "is_series"
+            ],
+            "propertyNames": {
+                "enum": [
+                    "id",
+                    "is_series"
+                ]
+            }
+        },
+        "behavior-overrides": {
+            "type": "object",
+            "description": "A JSON object that contains configuration settings that modify the behavior of the DA orchestration.",
+            "properties": {
+                "special_instructions": {
+                    "description": "An object that contains special instructions for the declarative agent.",
+                    "$ref": "#/$defs/special-instructions"
+                },
+                "suggestions": {
+                    "description": "An object that contains suggestions for behavior overrides for the declarative agent.",
+                    "$ref": "#/$defs/suggestions"
+                },
+                "default_response_mode": {
+                    "type": "string",
+                    "description": "Optional. The default response mode for the declarative agent.",
+                    "enum": [
+                        "Auto",
+                        "Quick response",
+                        "Think deeper"
+                    ]
+                }
+            },
+            "propertyNames": {
+                "enum": [
+                    "special_instructions",
+                    "suggestions",
+                    "default_response_mode"
+                ]
+            }
+        },
+        "special-instructions": {
+            "type": "object",
+            "description": "A JSON object that contains members used for injecting special instructions into the prompt. The object has a discourage_model_knowledge boolean property. If this property is set to true, the DA will be discouraged from using model knowledge when generating responses. The default value is false",
+            "properties": {
+                "discourage_model_knowledge": {
+                    "type": "boolean",
+                    "description": "A boolean value that indicates whether the declarative agent should be discouraged from using model knowledge when generating responses."
+                }
+            },
+            "propertyNames": {
+                "enum": [
+                    "discourage_model_knowledge"
+                ]
+            }
+        },
+        "suggestions": {
+            "type": "object",
+            "description": "A JSON object that contains configuration settings for the suggestions feature. The object has a required disabled boolean property. If this property is set to true, the suggestions feature will be disabled. The default value is false.",
+            "properties": {
+                "disabled": {
+                    "type": "boolean",
+                    "description": "A boolean value that indicates whether the suggestions feature is disabled. If this property is set to true, the suggestions feature will be disabled. The default value is false."
+                }
+            },
+            "propertyNames": {
+                "enum": [
+                    "disabled"
+                ]
+            }
+        },
+        "web-search-site": {
+            "type": "object",
+            "description": "An object that identifies a site used to constrain the content accessible to the declarative agent.",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": " An absolute URL to a site."
+                }
+            },
+            "required": [
+                "url"
+            ],
+            "propertyNames": {
+                "enum": [
+                    "url"
+                ]
+            }
+        },
+        "conversation-starter": {
+            "type": "object",
+            "description": "Contains hints that are displayed to the user to demonstrate how they can get started using the declarative agent.",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "description": "Required. Localizable. A suggestion that the user can use to obtain the desired result from the DC. It MUST contain at least one nonwhitespace character.",
+                    "pattern": "^(\\[\\[)[a-zA-Z_][a-zA-Z0-9_]*(\\]\\])$|^(?!(.*?\\[\\[.*?|.*?\\]\\].*?)).*$"
+                },
+                "title": {
+                    "type": "string",
+                    "description": "Optional. Localizable. A unique title for the conversation starter. It MUST contain at least one nonwhitespace character.",
+                    "pattern": "^(\\[\\[)[a-zA-Z_][a-zA-Z0-9_]*(\\]\\])$|^(?!(.*?\\[\\[.*?|.*?\\]\\].*?)).*$"
+                },
+                "depends_on": {
+                    "type": "array",
+                    "description": "Optional. A list of objects that specify dependencies for this conversation starter.",
+                    "items": {
+                        "$ref": "#/$defs/conversation-starter-depends-on"
+                    }
+                }
+            },
+            "required": [
+                "text"
+            ],
+            "propertyNames": {
+                "enum": [
+                    "text",
+                    "title",
+                    "depends_on"
+                ]
+            }
+        },
+        "action-object": {
+            "type": "object",
+            "description": "Identifies an API plugin manifest for a plugin used as an action by the declarative agent.",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "Required. Not localizable. A unique identifier for the action. It MAY be represented by a GUID.",
+                    "pattern": "^(?!\\[\\[)(.*?)(?<!\\]\\])$"
+                },
+                "file": {
+                    "type": "string",
+                    "description": "Required. Not localizable. A path to the API plugin manifest for this action.",
+                    "pattern": "^(?!\\[\\[)(.*?)(?<!\\]\\])$"
+                }
+            },
+            "required": [
+                "id",
+                "file"
+            ],
+            "propertyNames": {
+                "enum": [
+                    "id",
+                    "file"
+                ]
+            }
+        },
+        "sharepoint-ids": {
+            "type": "object",
+            "description": "Contains one or more object identifiers that identify a SharePoint or OneDrive resource.",
+            "properties": {
+                "site_id": {
+                    "type": "string",
+                    "description": "Optional. Not localizable. The GUID identifier of a SharePoint or OneDrive site.",
+                    "pattern": "^(?!\\[\\[)(.*?)(?<!\\]\\])$"
+                },
+                "web_id": {
+                    "type": "string",
+                    "description": "Optional. Not localizable. The GUID identifier of a SharePoint or OneDrive web.",
+                    "pattern": "^(?!\\[\\[)(.*?)(?<!\\]\\])$"
+                },
+                "list_id": {
+                    "type": "string",
+                    "description": "Optional. Not localizable. The GUID identifier of a SharePoint or OneDrive list.",
+                    "pattern": "^(?!\\[\\[)(.*?)(?<!\\]\\])$"
+                },
+                "unique_id": {
+                    "type": "string",
+                    "description": "Optional. Not localizable. The GUID identifier of a SharePoint or OneDrive item.",
+                    "pattern": "^(?!\\[\\[)(.*?)(?<!\\]\\])$"
+                },
+                "part_id": {
+                    "type": "string",
+                    "description": "A JSON String that uniquely identifies a part of a SharePoint item. e.g a OneNote page."
+                },
+                "part_type": {
+                    "type": "string",
+                    "description": "A String that qualifies the kind of part that the \"part_id\" refers to. Currently this value can only be equal to the string literal: \"OneNotePart\".",
+                    "enum": [
+                        "OneNotePart"
+                    ]
+                },
+                "search_associated_sites": {
+                    "type": "boolean",
+                    "description": "Boolean value indicating whether to enable searching associated sites. This value is only applicable when the site_id value references a SharePoint HubSite."
+                }
+            },
+            "propertyNames": {
+                "enum": [
+                    "site_id",
+                    "web_id",
+                    "list_id",
+                    "unique_id",
+                    "part_id",
+                    "part_type",
+                    "search_associated_sites"
+                ]
+            },
+            "additionalProperties": false
+        },
+        "sharepoint-url": {
+            "type": "object",
+            "description": "Represents the URL of a SharePoint or OneDrive resource.",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "Optional. Not localizable. An absolute URL to a SharePoint or OneDrive resource.",
+                    "pattern": "^(?!\\[\\[)(.*?)(?<!\\]\\])$"
+                }
+            },
+            "propertyNames": {
+                "enum": [
+                    "url"
+                ]
+            },
+            "additionalProperties": false
+        },
+        "connection": {
+            "type": "object",
+            "description": "Identifies a Microsoft Graph connector.",
+            "properties": {
+                "connection_id": {
+                    "type": "string",
+                    "description": "Required. Not localizable The unique identifier of the Microsoft Graph connector.",
+                    "pattern": "^(?!\\[\\[)(.*?)(?<!\\]\\])$"
+                },
+                "additional_search_terms": {
+                    "type": "string",
+                    "description": "KQL based string containing the query filter"
+                },
+                "items_by_external_url": {
+                    "type": "array",
+                    "description": "A list of objects to store urls for external items.",
+                    "items": {
+                        "$ref": "#/$defs/item-by-external-url"
+                    }
+                },
+                "items_by_external_id": {
+                    "type": "array",
+                    "description": "A list of objects to store identifiers for external items",
+                    "items": {
+                        "$ref": "#/$defs/item-by-external-id"
+                    }
+                },
+                "items_by_path": {
+                    "type": "array",
+                    "description": "A list of objects to store the container paths to items within a connection",
+                    "items": {
+                        "$ref": "#/$defs/item-by-path"
+                    }
+                },
+                "items_by_container_name": {
+                    "type": "array",
+                    "description": "A list of objects to store containers names",
+                    "uniqueItems": true,
+                    "items": {
+                        "$ref": "#/$defs/item-by-container-name"
+                    }
+                },
+                "items_by_container_url": {
+                    "type": "array",
+                    "description": "A list of objects to store urls of containers",
+                    "uniqueItems": true,
+                    "items": {
+                        "$ref": "#/$defs/item-by-container-url"
+                    }
+                }
+            },
+            "required": [
+                "connection_id"
+            ],
+            "propertyNames": {
+                "enum": [
+                    "connection_id",
+                    "additional_search_terms",
+                    "items_by_external_url",
+                    "items_by_external_id",
+                    "items_by_path",
+                    "items_by_container_name",
+                    "items_by_container_url"
+                ]
+            }
+        },
+        "item-by-external-url": {
+            "type": "object",
+            "description": "Identifies an item by its external URL.",
+            "properties": {
+                "url": {
+                    "type": "string",
+                    "description": "Url for external graph connector item."
+                }
+            },
+            "required": [
+                "url"
+            ],
+            "propertyNames": {
+                "enum": [
+                    "url"
+                ]
+            }
+        },
+        "item-by-external-id": {
+            "type": "object",
+            "description": "Identifies an item by its external ID.",
+            "properties": {
+                "item_id": {
+                    "type": "string",
+                    "description": "A unique identifier for an external item."
+                }
+            },
+            "required": [
+                "item_id"
+            ],
+            "propertyNames": {
+                "enum": [
+                    "item_id"
+                ]
+            }
+        },
+        "item-by-path": {
+            "type": "object",
+            "description": "Identifies an item by its path.",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "A container path to an external item"
+                }
+            },
+            "required": [
+                "path"
+            ],
+            "propertyNames": {
+                "enum": [
+                    "path"
+                ]
+            }
+        },
+        "item-by-container-name": {
+            "type": "object",
+            "description": "Identifies an item by its container name.",
+            "properties": {
+                "container_name": {
+                    "type": "string",
+                    "description": "A unique identifier for a container name"
+                }
+            },
+            "required": [
+                "container_name"
+            ],
+            "propertyNames": {
+                "enum": [
+                    "container_name"
+                ]
+            }
+        },
+        "item-by-container-url": {
+            "type": "object",
+            "description": "Identifies an item by its container URL.",
+            "properties": {
+                "container_url": {
+                    "type": "string",
+                    "description": "Url for external graph connector item container"
+                }
+            },
+            "required": [
+                "container_url"
+            ],
+            "propertyNames": {
+                "enum": [
+                    "container_url"
+                ]
+            }
+        },
+        "sensitivity-label-object": {
+            "type": "object",
+            "description": "A JSON object that specifies the sensitivity label for the DA. The GUID should match one of the published sensitivity labels within the tenant.",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "Required. The GUID of the sensitivity label pulled from the Purview API."
+                }
+            },
+            "required": [
+                "id"
+            ],
+            "propertyNames": {
+                "enum": [
+                    "id"
+                ]
+            }
+        },
+        "conversation-starter-depends-on": {
+            "type": "object",
+            "description": "An object that identifies a dependency for a conversation starter.",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "Required. The identifier of the dependency."
+                },
+                "name": {
+                    "type": "string",
+                    "description": "Required. The name of the dependency."
+                }
+            },
+            "required": [
+                "id",
+                "name"
+            ],
+            "propertyNames": {
+                "pattern": "^(id|name|x-.*)$"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Publishes the declarative agent v1.8 JSON schema from merged main PR #613 to the `live` branch.

## Changes

- Adds only `copilot/declarative-agent/v1.8/schema.json`.
- Cherry-picks the schema file from main merge commit `34356d97e1218c79331780f8f5b77b03f2d13f35`.
- Preserves the exact authoritative MVL `support/v1` schema blob (`c31e306d15cdec45dd21efb844235c0a4edb99e1`).

## Validation

Validated locally with VS Code's JSON language service using a `da.json` manifest-level `$schema` reference to `https://developer.microsoft.com/json-schemas/copilot/declarative-agent/v1.8/schema.json`.

The 14 editor scenarios covered:

- Valid `EmailActions` and `MeetingActions` capabilities individually and together.
- Compatibility with the related `Email` and `Meetings` read capabilities.
- Invalid casing, unsupported properties, missing capability names, duplicate capabilities, and incorrect manifest version.
- Editor completion suggestions for both new capability names.
- Resolution of the schema through the manifest `$schema` field.

No test files are included in this PR.
