### PR TITLE
Add MirroredGoogleLakehouseRuntimeCatalog to MirroredCatalog SourceType enum

### DIFF
--- a/fabric/item/mirroredCatalog/definition/mirroredCatalogDefinition/1.0.0/schema.json
+++ b/fabric/item/mirroredCatalog/definition/mirroredCatalogDefinition/1.0.0/schema.json
@@ -62,7 +62,8 @@
       "enum": [
         "DremioIcebergCatalog",
         "AzureMonitorMirroredCatalog",
-        "AWSIcebergCatalog"
+        "AWSIcebergCatalog",
+        "MirroredGoogleLakehouseRuntimeCatalog"
       ]
     },
     "SourceTypeProperties": {


### PR DESCRIPTION
Adds the Google Lakehouse Runtime Catalog provider to the `SourceType` enum in `fabric/item/mirroredCatalog/definition/mirroredCatalogDefinition/1.0.0/schema.json`.

```diff
   "AzureMonitorMirroredCatalog",
-  "AWSIcebergCatalog"
+  "AWSIcebergCatalog",
+  "MirroredGoogleLakehouseRuntimeCatalog"
```

### Why 1.0.0 is edited in place rather than version-bumped

Adding an enum value is backward compatible, the schema's own `SourceType` description already states that *"Additional source types may be added over time"*, and keeping the version stable leaves every existing `$schema` URL and base64-encoded definition payload valid. This matches how `AzureMonitorMirroredCatalog` and `AWSIcebergCatalog` were added previously.

### On the value itself

The exact enum value is `MirroredGoogleLakehouseRuntimeCatalog` - note the `Mirrored` prefix. It is the source kind emitted by the connector, which the Fabric workload requires to equal the item definition's `properties.source.type`.

A companion PR updates the matching `SourceType` table in the Mirrored Catalog item-definition article.