### PR TITLE
fix: discriminate plugin v2.4 runtime.spec by runtime type

### DIFF
--- a/copilot/plugin/v2.4/schema.json
+++ b/copilot/plugin/v2.4/schema.json
@@ -528,10 +528,7 @@
             "properties": {
                 "local_endpoint": {
                     "type": "string",
-                    "description": "A JSON string that represents a local runtime identifier that links to a specific function to invoke locally (e.g. in the case of Windows it will link to a particular app). In the case of an Office Addin that is implementing the function, the value MUST be the string Microsoft.Office.Addin.",
-                    "enum": [
-                        "Microsoft.Office.Addin"
-                    ]
+                    "description": "A JSON string that represents a local runtime identifier that links to a specific function to invoke locally (e.g. in the case of Windows it will link to a particular app). In the case of an Office Addin that is implementing the function, the value MUST be the string Microsoft.Office.Addin."
                 },
                 "allowed_host": {
                     "type": "array",

--- a/copilot/plugin/v2.4/schema.json
+++ b/copilot/plugin/v2.4/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
     "$comment": "This schema describes the constraints of a plugin manifest for third party developers to be deployed to Microsoft 365 Copilot",
     "type": "object",
     "title": "API Plugin manifest object",
@@ -353,61 +353,40 @@
             "patternProperties": {
                 "^x-": {}
             },
-            "allOf": [
+            "oneOf": [
                 {
-                    "if": {
-                        "required": [
-                            "type"
-                        ],
-                        "properties": {
-                            "type": {
-                                "const": "OpenApi"
-                            }
-                        }
-                    },
-                    "then": {
-                        "properties": {
-                            "spec": {
-                                "$ref": "#/$defs/open-api-spec"
-                            }
+                    "properties": {
+                        "type": {
+                            "enum": [
+                                "OpenApi"
+                            ]
+                        },
+                        "spec": {
+                            "$ref": "#/$defs/open-api-spec"
                         }
                     }
                 },
                 {
-                    "if": {
-                        "required": [
-                            "type"
-                        ],
-                        "properties": {
-                            "type": {
-                                "const": "LocalPlugin"
-                            }
-                        }
-                    },
-                    "then": {
-                        "properties": {
-                            "spec": {
-                                "$ref": "#/$defs/local-plugin-spec"
-                            }
+                    "properties": {
+                        "type": {
+                            "enum": [
+                                "LocalPlugin"
+                            ]
+                        },
+                        "spec": {
+                            "$ref": "#/$defs/local-plugin-spec"
                         }
                     }
                 },
                 {
-                    "if": {
-                        "required": [
-                            "type"
-                        ],
-                        "properties": {
-                            "type": {
-                                "const": "RemoteMCPServer"
-                            }
-                        }
-                    },
-                    "then": {
-                        "properties": {
-                            "spec": {
-                                "$ref": "#/$defs/mcp-execution-spec"
-                            }
+                    "properties": {
+                        "type": {
+                            "enum": [
+                                "RemoteMCPServer"
+                            ]
+                        },
+                        "spec": {
+                            "$ref": "#/$defs/mcp-execution-spec"
                         }
                     }
                 }

--- a/copilot/plugin/v2.4/schema.json
+++ b/copilot/plugin/v2.4/schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-07/schema#",
     "$comment": "This schema describes the constraints of a plugin manifest for third party developers to be deployed to Microsoft 365 Copilot",
     "type": "object",
     "title": "API Plugin manifest object",
@@ -341,18 +341,8 @@
                     }
                 },
                 "spec": {
-                    "description": "Runtime-specific configuration object.",
-                    "oneOf": [
-                        {
-                            "$ref": "#/$defs/open-api-spec"
-                        },
-                        {
-                            "$ref": "#/$defs/local-plugin-spec"
-                        },
-                        {
-                            "$ref": "#/$defs/mcp-execution-spec"
-                        }
-                    ]
+                    "description": "Runtime-specific configuration object. The exact shape is selected by the runtime `type`.",
+                    "type": "object"
                 },
                 "output_template": {
                     "type": "string",
@@ -362,7 +352,66 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-": {}
-            }
+            },
+            "allOf": [
+                {
+                    "if": {
+                        "required": [
+                            "type"
+                        ],
+                        "properties": {
+                            "type": {
+                                "const": "OpenApi"
+                            }
+                        }
+                    },
+                    "then": {
+                        "properties": {
+                            "spec": {
+                                "$ref": "#/$defs/open-api-spec"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "required": [
+                            "type"
+                        ],
+                        "properties": {
+                            "type": {
+                                "const": "LocalPlugin"
+                            }
+                        }
+                    },
+                    "then": {
+                        "properties": {
+                            "spec": {
+                                "$ref": "#/$defs/local-plugin-spec"
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "required": [
+                            "type"
+                        ],
+                        "properties": {
+                            "type": {
+                                "const": "RemoteMCPServer"
+                            }
+                        }
+                    },
+                    "then": {
+                        "properties": {
+                            "spec": {
+                                "$ref": "#/$defs/mcp-execution-spec"
+                            }
+                        }
+                    }
+                }
+            ]
         },
         "auth-object": {
             "type": "object",
@@ -551,7 +600,19 @@
         "mcp-tool-inline": {
             "type": "object",
             "title": "MCP Tool Inline Definitions",
-            "description": "Inline tool definitions matching the format returned by the MCP server's tools/list method."
+            "description": "Inline tool definitions matching the format returned by the MCP server's tools/list method.",
+            "required": [
+                "tools"
+            ],
+            "properties": {
+                "tools": {
+                    "type": "array",
+                    "description": "An array of tool definition objects matching the format returned by the MCP server's tools/list method.",
+                    "items": {
+                        "type": "object"
+                    }
+                }
+            }
         },
         "function-parameters": {
             "type": "object",


### PR DESCRIPTION
Fixes #617.

## Problem

`runtime.spec` used a `oneOf` across `open-api-spec`, `local-plugin-spec` and `mcp-execution-spec` with no discriminator. A bare `{ "url": "..." }` satisfies **both** `open-api-spec` (whose `anyOf` needs `url` *or* `api_description`) and `mcp-execution-spec` (which requires `url`), so two subschemas match and `oneOf` fails.

This rejects the most common runtime shapes for both `OpenApi` and `RemoteMCPServer`, including the dynamic-discovery example published in the v2.4 specification:

```json
{ "type": "RemoteMCPServer", "spec": { "url": "https://mcp.example.org/" } }
```

Because the ambiguity was resolved by property shape rather than by `type`, the schema was simultaneously too strict *and* too loose: it also silently accepted mismatched pairings such as `type: "OpenApi"` with a `local_endpoint` spec.

Two further defects surfaced while validating the fix, both of which reject examples published in the specification:

- `mcp-tool-inline` was an unconstrained `{ "type": "object" }`, so it also matched `{ "file": "..." }`. That made the **File Reference Format** — the first MCP example in the spec — impossible to validate.
- `local_endpoint` was constrained to `enum: ["Microsoft.Office.Addin"]`, which rejects the Windows local runtime identifier documented in the spec appendix (`MicrosoftWindows.Client.CoPilotCanary_.../WindowsSettingsPlugin`). The spec describes `local_endpoint` as a general local runtime identifier and only mandates `Microsoft.Office.Addin` for the Office Add-in case.

## Fix

1. Discriminate on `type` by moving the `oneOf` up to the **runtime object**, where each branch pins `type` and `spec` together. Because the `type` values are mutually exclusive, exactly one branch can match.
2. Constrain `mcp-tool-inline` to require `tools`, so the file-reference and inline formats are unambiguous.
3. Drop the `local_endpoint` enum so non-Office local runtime identifiers validate.

`spec` remains `"type": "object"` and required; the per-type shape is applied by the `oneOf` branches.

## Dialect: deliberately still draft-04

The first revision of this PR used draft-07 `if`/`then` and bumped `$schema`. **That would have broken the Microsoft 365 Agents Toolkit.** ATK selects its validator by inspecting the schema's `$schema` and only uses `Ajv2020` when the value contains `2020-12`; every other dialect — including draft-07 — falls through to **`ajv-draft-04`**, which is draft-04 only.

Reproduced against `ajv-draft-04@1.0.0` using ATK's own constructor options:

```
$schema: http://json-schema.org/draft-07/schema#
ATK path: ajv-draft-04
COMPILE: THREW -> no schema with key or ref "http://json-schema.org/draft-07/schema#"
```

That is a hard compile failure, so a draft-07 schema would have taken out ATK's local manifest validation entirely — a worse outcome than the bug being fixed. The final revision therefore keeps `$schema` at draft-04 and uses only draft-04 keywords (`oneOf`, `properties`, `enum`, `$ref`), which every affected engine already supports.

## Validation

Verified on three independent engines. Every valid shape passes and every invalid shape is still rejected, so the discrimination is genuinely enforced rather than silently skipped.

| Engine | Why it matters | Result |
|---|---|---|
| `ajv-draft-04` 1.0.0 | the path ATK actually takes | 9/9 |
| `vscode-json-languageservice` 6.0.0-next.2 | bundled by VS Code 1.130 | 17/17 |
| `vscode-json-languageservice` 4.1.6 | oldest release on npm | 17/17 |
| `ajv` 8.20 (draft-07) | general-purpose validators | 18/18 |

Case-level results:

| Case | Before | After |
|---|---|---|
| `OpenApi` `{ url }` | rejected | **valid** |
| `OpenApi` `{ api_description }` | valid | valid |
| `OpenApi` `{ url, progress_style }` | valid | valid |
| `LocalPlugin` `{ local_endpoint, allowed_host }` | valid | valid |
| `LocalPlugin` Windows `local_endpoint` (spec appendix) | rejected | **valid** |
| `RemoteMCPServer` `{ url }` (dynamic discovery) | rejected | **valid** |
| `RemoteMCPServer` `{ url, mcp_tool_description.file }` | rejected | **valid** |
| `RemoteMCPServer` `{ url, mcp_tool_description.tools }` | valid | valid |
| `OpenApi` with a `LocalPlugin` spec | valid | **rejected** |
| `RemoteMCPServer` with a `LocalPlugin` spec | valid | **rejected** |
| `LocalPlugin` with an `OpenApi` spec | rejected | rejected |
| `OpenApi` with neither `url` nor `api_description` | rejected | rejected |
| `RemoteMCPServer` missing `url` | rejected | rejected |
| `LocalPlugin` invalid `allowed_host` value | rejected | rejected |
| `OpenApi` unknown property in `spec` | rejected | rejected |
| `OpenApi` invalid `progress_style` value | rejected | rejected |
| Invalid runtime `type` | rejected | rejected |

Net effect: 4 valid shapes that were wrongly rejected now pass, and 2 mismatched pairings that were wrongly accepted are now rejected. No case became more permissive.

Against the unfixed schema, VS Code's engine reports `Matches multiple schemas when only one must validate.` on `runtimes/0/spec` — the editor-side wording of #617.

## Note on scope

`mcp_tool_description` containing both `file` and `tools` stays valid, which matches the behavior of the server-side validator. Tightening it here would introduce a new client/server divergence of exactly the kind this PR removes.

## Related

[microsoft/Microsoft.Plugins.Manifest#987](https://github.com/microsoft/Microsoft.Plugins.Manifest/pull/987) applies the equivalent `spec` discriminator fix to the upstream source schema, so the two copies stay aligned. The `mcp-tool-inline` and `local_endpoint` defects are specific to this published copy and do not exist upstream.