### PR TITLE
chore: Update Plugin Schema v2.4

### DIFF
--- a/copilot/plugin/v2.4/schema.json
+++ b/copilot/plugin/v2.4/schema.json
@@ -341,18 +341,8 @@
                     }
                 },
                 "spec": {
-                    "description": "Runtime-specific configuration object.",
-                    "oneOf": [
-                        {
-                            "$ref": "#/$defs/open-api-spec"
-                        },
-                        {
-                            "$ref": "#/$defs/local-plugin-spec"
-                        },
-                        {
-                            "$ref": "#/$defs/mcp-execution-spec"
-                        }
-                    ]
+                    "description": "Runtime-specific configuration object. The exact shape is selected by the runtime `type`.",
+                    "type": "object"
                 },
                 "output_template": {
                     "type": "string",
@@ -362,7 +352,45 @@
             "additionalProperties": false,
             "patternProperties": {
                 "^x-": {}
-            }
+            },
+            "oneOf": [
+                {
+                    "properties": {
+                        "type": {
+                            "enum": [
+                                "OpenApi"
+                            ]
+                        },
+                        "spec": {
+                            "$ref": "#/$defs/open-api-spec"
+                        }
+                    }
+                },
+                {
+                    "properties": {
+                        "type": {
+                            "enum": [
+                                "LocalPlugin"
+                            ]
+                        },
+                        "spec": {
+                            "$ref": "#/$defs/local-plugin-spec"
+                        }
+                    }
+                },
+                {
+                    "properties": {
+                        "type": {
+                            "enum": [
+                                "RemoteMCPServer"
+                            ]
+                        },
+                        "spec": {
+                            "$ref": "#/$defs/mcp-execution-spec"
+                        }
+                    }
+                }
+            ]
         },
         "auth-object": {
             "type": "object",
@@ -479,10 +507,7 @@
             "properties": {
                 "local_endpoint": {
                     "type": "string",
-                    "description": "A JSON string that represents a local runtime identifier that links to a specific function to invoke locally (e.g. in the case of Windows it will link to a particular app). In the case of an Office Addin that is implementing the function, the value MUST be the string Microsoft.Office.Addin.",
-                    "enum": [
-                        "Microsoft.Office.Addin"
-                    ]
+                    "description": "A JSON string that represents a local runtime identifier that links to a specific function to invoke locally (e.g. in the case of Windows it will link to a particular app). In the case of an Office Addin that is implementing the function, the value MUST be the string Microsoft.Office.Addin."
                 },
                 "allowed_host": {
                     "type": "array",
@@ -551,7 +576,19 @@
         "mcp-tool-inline": {
             "type": "object",
             "title": "MCP Tool Inline Definitions",
-            "description": "Inline tool definitions matching the format returned by the MCP server's tools/list method."
+            "description": "Inline tool definitions matching the format returned by the MCP server's tools/list method.",
+            "required": [
+                "tools"
+            ],
+            "properties": {
+                "tools": {
+                    "type": "array",
+                    "description": "An array of tool definition objects matching the format returned by the MCP server's tools/list method.",
+                    "items": {
+                        "type": "object"
+                    }
+                }
+            }
         },
         "function-parameters": {
             "type": "object",


### PR DESCRIPTION
Publishes the plugin manifest v2.4 schema fix from `main` to `live`.

Cherry-picks `9eeffd221958313997b985490ff525629f9a5336` (squash merge of #622) with `-x` for provenance. Scoped to a single file — `copilot/plugin/v2.4/schema.json` — and the resulting blob is byte-identical to `main`.

## What this fixes

Reported in #617. `runtime.spec` used a `oneOf` with no discriminator, so a bare `{ "url": "..." }` matched **both** `open-api-spec` (whose `anyOf` needs `url` *or* `api_description`) and `mcp-execution-spec` (which requires `url`). Two subschemas matched, `oneOf` failed, and valid manifests were rejected — including the dynamic-discovery example published in the v2.4 specification.

The same PR also fixed two related defects that rejected published spec examples:

- `mcp-tool-inline` was an unconstrained object, so it also matched `{ "file": "..." }`, making the MCP **File Reference Format** impossible to validate.
- `local_endpoint` was pinned to `enum: ["Microsoft.Office.Addin"]`, which rejected the Windows local runtime identifier from the spec appendix.

Discrimination is now done with a `oneOf` on the runtime object where each branch pins `type` and `spec` together.

## Compatibility

The schema stays on **draft-04**. An earlier revision used draft-07 `if`/`then`, but that would have broken the Microsoft 365 Agents Toolkit, which routes every non-`2020-12` dialect to `ajv-draft-04` and fails to compile draft-07 outright. Keeping the dialect unchanged means there is no minimum VS Code or ATK version requirement.

Re-verified on this branch:

| Engine | Why it matters | Result |
|---|---|---|
| `ajv-draft-04` 1.0.0 | the path ATK actually takes | 9/9 |
| `vscode-json-languageservice` 6.0.0-next.2 | bundled by VS Code 1.130 | 17/17 |
| `vscode-json-languageservice` 4.1.6 | oldest release on npm | 17/17 |
| `ajv` 8.20 | general-purpose validators | 18/18 |

Net effect: 4 valid manifest shapes that were wrongly rejected now pass, and 2 mismatched `type`/`spec` pairings that were wrongly accepted are now rejected. No case became more permissive.

## Related

- #617 — original report
- #622 — the `main` PR being published here
- [microsoft/Microsoft.Plugins.Manifest#987](https://github.com/microsoft/Microsoft.Plugins.Manifest/pull/987) — equivalent fix in the upstream source schema