### PR TITLE
Fix visualConfiguration schema identities

### DIFF
--- a/fabric/item/report/definition/visualConfiguration/1.8.0/schema-embedded.json
+++ b/fabric/item/report/definition/visualConfiguration/1.8.0/schema-embedded.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualConfiguration/1.8.0/schema.json",
+    "$id": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualConfiguration/1.8.0/schema-embedded.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Visual configuration",
     "description": "Defines the configuration of visuals.",

--- a/fabric/item/report/definition/visualConfiguration/2.0.0/schema.json
+++ b/fabric/item/report/definition/visualConfiguration/2.0.0/schema.json
@@ -1,5 +1,5 @@
 {
-    "$id": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualConfiguration/2.1.0/schema.json",
+    "$id": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualConfiguration/2.0.0/schema.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "Visual configuration",
     "description": "Defines the configuration of visuals.",
@@ -8,7 +8,7 @@
         "$schema": {
             "description": "Defines the schema to use for an item.",
             "type": "string",
-            "const": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualConfiguration/2.1.0/schema.json"
+            "const": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/visualConfiguration/2.0.0/schema.json"
         },
         "visualType": {
             "description": "Name of the visual.",


### PR DESCRIPTION
## Problem

Two visual configuration schemas advertise identities that do not match the files from which they are published:

1. `visualConfiguration/2.0.0/schema.json` advertises the `2.1.0` URL in both its `$id` and `properties.$schema.const`.
2. `visualConfiguration/1.8.0/schema-embedded.json` claims the `$id` of its sibling `schema.json`, so two different schemas share one identity.

## Fix

- Change the two self-identifying values in `2.0.0/schema.json` from `2.1.0` to `2.0.0`.
- Change the embedded 1.8.0 schema's `$id` to its own `schema-embedded.json` publication path.

The dependency upgrades introduced deliberately in PR #371 remain unchanged:

- `formattingObjectDefinitions/1.4.0`
- `semanticQuery/1.3.0`

## Validation

- Existing suite: **528 passed**
- Final diff: **two files, 3 insertions / 3 deletions**
- Confirmed all 16 `formattingObjectDefinitions` references remain on `1.4.0`
- Confirmed all 6 `semanticQuery` references remain on `1.3.0`