### PR TITLE
Update Map v2.1.0 schema to match final release definition

### DIFF
--- a/fabric/item/map/definition/2.1.0/schema.json
+++ b/fabric/item/map/definition/2.1.0/schema.json
@@ -5,6 +5,34 @@
   "type": "object",
   "additionalProperties": false,
   "$defs": {
+    "styleExpression": {
+      "title": "Style expression",
+      "description": "A style expression encoded as a JSON array, used to derive a value from each feature rather than applying one fixed value to the whole layer. The first element is the expression operator and the remaining elements are its arguments, which can themselves be expressions. Expressions are evaluated while rendering, using feature properties and map state. Common operators include data accessors such as get, conditional operators such as case and match, and scaling operators such as interpolate and step.",
+      "type": "array",
+      "minItems": 1,
+      "items": [
+        {
+          "type": "string",
+          "description": "The expression operator, such as get, match, step, or interpolate"
+        }
+      ],
+      "additionalItems": true,
+      "examples": [
+        ["get", "height"],
+        ["match", ["get", "category"], "A", "red", "blue"]
+      ]
+    },
+    "numberOrStyleExpression": {
+      "description": "A fixed number or a style expression that evaluates to a number.",
+      "oneOf": [
+        {
+          "type": "number"
+        },
+        {
+          "$ref": "#/$defs/styleExpression"
+        }
+      ]
+    },
     "colorDefinition": {
       "oneOf": [
         {
@@ -16,6 +44,26 @@
           "description": "A data-driven expression array for dynamic styling"
         }
       ]
+    },
+    "valueRangeColorStep": {
+      "type": "object",
+      "description": "A color assigned to a numeric value range. 'min' and 'color' define the step boundary used for rendering; 'max' is the upper bound used for legend display.",
+      "additionalProperties": false,
+      "properties": {
+        "min": {
+          "type": "number",
+          "description": "Inclusive lower bound of the value range"
+        },
+        "max": {
+          "type": "number",
+          "description": "Upper bound of the value range, used for legend labels"
+        },
+        "color": {
+          "type": "string",
+          "description": "CSS color string applied to values in this range"
+        }
+      },
+      "required": ["min", "color"]
     }
   },
   "properties": {
@@ -324,7 +372,7 @@
                 "description": "Defines custom properties that are calculated using expressions against all the points within each cluster and added to the properties of each cluster point",
                 "additionalProperties": {
                   "type": "array",
-                  "description": "An aggregate expression in the form [operator, mapExpression] or for three-argument operators [operator, mapExpression, reduceExpression]"
+                  "description": "An aggregate expression in the form [operator, mapExpression], or [operator, initialValue, mapExpression] when an initial value is supplied. The operator is applied across all points in the cluster to the values produced by the map expression. Supported operators are '+', '*', 'max' and 'min' for numbers, and 'all' and 'any' for booleans."
                 }
               },
               "clusterField": {
@@ -334,6 +382,24 @@
               "clusterType": {
                 "type": "string",
                 "description": "Type of cluster aggregation to perform"
+              },
+              "featureServiceQuery": {
+                "type": "object",
+                "description": "Server-side query settings for connection-backed feature services",
+                "additionalProperties": false,
+                "properties": {
+                  "outputFields": {
+                    "type": "array",
+                    "description": "Property names to request from the feature service",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "filter": {
+                    "type": "string",
+                    "description": "Protocol-native server-side filter expression"
+                  }
+                }
               }
             }
           },
@@ -510,6 +576,38 @@
                     "type": "string",
                     "description": "ID of the color palette to use for data-driven colors"
                   },
+                  "seriesGroupType": {
+                    "type": "string",
+                    "description": "Type of data-driven series grouping",
+                    "enum": ["category", "range"]
+                  },
+                  "seriesGroupRange": {
+                    "type": "string",
+                    "description": "Rendering mode for range-based series grouping",
+                    "enum": ["gradient", "step"]
+                  },
+                  "gradientId": {
+                    "type": "string",
+                    "description": "ID of the predefined color gradient"
+                  },
+                  "stepId": {
+                    "type": "string",
+                    "description": "ID of the predefined stepped color palette"
+                  },
+                  "customGradientColors": {
+                    "type": "array",
+                    "description": "Custom colors for a range-based gradient",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "customStepColors": {
+                    "type": "array",
+                    "description": "Custom colors for stepped numeric ranges",
+                    "items": {
+                      "$ref": "#/$defs/valueRangeColorStep"
+                    }
+                  },
                   "customColors": {
                     "type": "object",
                     "description": "Custom colors for data-driven styling. Keys are series values, values are color strings.",
@@ -537,8 +635,11 @@
                     "description": "The radius in pixels used to render a data point on the heatmap. The radius must be a number greater or equal to 1"
                   },
                   "weight": {
-                    "type": "number",
-                    "description": "Specifies how much an individual data point contributes to the heatmap. Must be a number greater than 0. A value of 5 would be equivalent to having 5 points of weight 1 in the same spot. This is useful when clustering points to allow heatmap rendering or large datasets"
+                    "$ref": "#/$defs/numberOrStyleExpression"
+                  },
+                  "color": {
+                    "description": "The color gradient used to render heatmap density, normally a style expression over ['heatmap-density']",
+                    "$ref": "#/$defs/colorDefinition"
                   }
                 }
               },
@@ -554,6 +655,49 @@
                   "seriesGroup": {
                     "type": "string",
                     "description": "Property key to use for series grouping"
+                  },
+                  "seriesGroupType": {
+                    "type": "string",
+                    "description": "Type of data-driven series grouping",
+                    "enum": ["category", "range"]
+                  },
+                  "seriesGroupRange": {
+                    "type": "string",
+                    "description": "Rendering mode for range-based series grouping",
+                    "enum": ["gradient", "step"]
+                  },
+                  "paletteId": {
+                    "type": "string",
+                    "description": "ID of the color palette to use for data-driven colors"
+                  },
+                  "gradientId": {
+                    "type": "string",
+                    "description": "ID of the predefined color gradient"
+                  },
+                  "stepId": {
+                    "type": "string",
+                    "description": "ID of the predefined stepped color palette"
+                  },
+                  "customColors": {
+                    "type": "object",
+                    "description": "Custom colors for data-driven styling. Keys are series values, values are color strings.",
+                    "additionalProperties": {
+                      "$ref": "#/$defs/colorDefinition"
+                    }
+                  },
+                  "customGradientColors": {
+                    "type": "array",
+                    "description": "Custom colors for a range-based gradient",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "customStepColors": {
+                    "type": "array",
+                    "description": "Custom colors for stepped numeric ranges",
+                    "items": {
+                      "$ref": "#/$defs/valueRangeColorStep"
+                    }
                   },
                   "fillColor": {
                     "description": "The color to fill the marker with",
@@ -579,14 +723,32 @@
                     "type": "string",
                     "description": "Icon name to use for the marker"
                   },
+                  "rotationType": {
+                    "type": "string",
+                    "description": "Whether marker rotation is fixed or data-driven",
+                    "enum": ["fixed", "data-driven"]
+                  },
+                  "rotationProperty": {
+                    "type": "string",
+                    "description": "Property name used for data-driven marker rotation"
+                  },
                   "iconOptions": {
                     "type": "object",
                     "description": "Options used to customize the rendering behavior of marker icons",
                     "additionalProperties": false,
                     "properties": {
                       "image": {
-                        "type": "string",
-                        "description": "The name of the image in the map's image sprite to use for drawing the icon"
+                        "description": "The image name or style expression used to draw the icon",
+                        "oneOf": [
+                          {
+                            "type": "string",
+                            "description": "A fixed image name",
+                            "examples": ["layer:pin"]
+                          },
+                          {
+                            "$ref": "#/$defs/styleExpression"
+                          }
+                        ]
                       },
                       "anchor": {
                         "type": "string",
@@ -650,6 +812,38 @@
                     "type": "string",
                     "description": "ID of the color palette to use for data-driven colors"
                   },
+                  "seriesGroupType": {
+                    "type": "string",
+                    "description": "Type of data-driven series grouping",
+                    "enum": ["category", "range"]
+                  },
+                  "seriesGroupRange": {
+                    "type": "string",
+                    "description": "Rendering mode for range-based series grouping",
+                    "enum": ["gradient", "step"]
+                  },
+                  "gradientId": {
+                    "type": "string",
+                    "description": "ID of the predefined color gradient"
+                  },
+                  "stepId": {
+                    "type": "string",
+                    "description": "ID of the predefined stepped color palette"
+                  },
+                  "customGradientColors": {
+                    "type": "array",
+                    "description": "Custom colors for a range-based gradient",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "customStepColors": {
+                    "type": "array",
+                    "description": "Custom colors for stepped numeric ranges",
+                    "items": {
+                      "$ref": "#/$defs/valueRangeColorStep"
+                    }
+                  },
                   "customColors": {
                     "type": "object",
                     "description": "Custom colors for data-driven styling. Keys are series values, values are color strings.",
@@ -684,6 +878,38 @@
                     "type": "string",
                     "description": "ID of the color palette to use for data-driven colors"
                   },
+                  "seriesGroupType": {
+                    "type": "string",
+                    "description": "Type of data-driven series grouping",
+                    "enum": ["category", "range"]
+                  },
+                  "seriesGroupRange": {
+                    "type": "string",
+                    "description": "Rendering mode for range-based series grouping",
+                    "enum": ["gradient", "step"]
+                  },
+                  "gradientId": {
+                    "type": "string",
+                    "description": "ID of the predefined color gradient"
+                  },
+                  "stepId": {
+                    "type": "string",
+                    "description": "ID of the predefined stepped color palette"
+                  },
+                  "customGradientColors": {
+                    "type": "array",
+                    "description": "Custom colors for a range-based gradient",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "customStepColors": {
+                    "type": "array",
+                    "description": "Custom colors for stepped numeric ranges",
+                    "items": {
+                      "$ref": "#/$defs/valueRangeColorStep"
+                    }
+                  },
                   "customColors": {
                     "type": "object",
                     "description": "Custom colors for data-driven styling. Keys are series values, values are color strings.",
@@ -706,13 +932,71 @@
                     "type": "number",
                     "description": "A number between 0 and 1 that indicates the opacity at which the fill will be drawn"
                   },
+                  "enableSeriesGroup": {
+                    "type": "boolean",
+                    "description": "Enable grouping by series for color differentiation"
+                  },
+                  "seriesGroup": {
+                    "type": "string",
+                    "description": "Property key to use for series grouping"
+                  },
+                  "seriesGroupType": {
+                    "type": "string",
+                    "description": "Type of data-driven series grouping",
+                    "enum": ["category", "range"]
+                  },
+                  "seriesGroupRange": {
+                    "type": "string",
+                    "description": "Rendering mode for range-based series grouping",
+                    "enum": ["gradient", "step"]
+                  },
+                  "paletteId": {
+                    "type": "string",
+                    "description": "ID of the color palette to use for data-driven colors"
+                  },
+                  "gradientId": {
+                    "type": "string",
+                    "description": "ID of the predefined color gradient"
+                  },
+                  "stepId": {
+                    "type": "string",
+                    "description": "ID of the predefined stepped color palette"
+                  },
+                  "customColors": {
+                    "type": "object",
+                    "description": "Custom colors for data-driven styling. Keys are series values, values are color strings.",
+                    "additionalProperties": {
+                      "$ref": "#/$defs/colorDefinition"
+                    }
+                  },
+                  "customGradientColors": {
+                    "type": "array",
+                    "description": "Custom colors for a range-based gradient",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "customStepColors": {
+                    "type": "array",
+                    "description": "Custom colors for stepped numeric ranges",
+                    "items": {
+                      "$ref": "#/$defs/valueRangeColorStep"
+                    }
+                  },
                   "height": {
-                    "type": "number",
-                    "description": "The height in meters to extrude this layer. This height is relative to the ground. Must be a number greater or equal to 0"
+                    "$ref": "#/$defs/numberOrStyleExpression"
                   },
                   "base": {
                     "type": "number",
                     "description": "The height in meters to extrude the base of this layer. This height is relative to the ground. Must be greater or equal to 0 and less than or equal to height"
+                  },
+                  "heightProperty": {
+                    "type": "string",
+                    "description": "Property name containing the polygon extrusion height"
+                  },
+                  "accurateHeight": {
+                    "type": "boolean",
+                    "description": "Use the property's numeric value directly as the extrusion height"
                   }
                 }
               },
@@ -724,6 +1008,10 @@
                   "enabled": {
                     "type": "boolean",
                     "description": "Whether data labels are enabled"
+                  },
+                  "fontWeight": {
+                    "type": "string",
+                    "description": "Font weight for data labels"
                   },
                   "color": {
                     "description": "Text color",
@@ -744,6 +1032,16 @@
                   "allowOverlap": {
                     "type": "boolean",
                     "description": "Allow text overlap with other symbols"
+                  },
+                  "anchor": {
+                    "type": "string",
+                    "description": "Anchor position for data-label text",
+                    "enum": ["center", "top", "bottom", "left", "right", "top-left", "top-right", "bottom-left", "bottom-right"]
+                  },
+                  "placement": {
+                    "type": "string",
+                    "description": "Placement strategy for data-label text",
+                    "enum": ["point", "line-center"]
                   }
                 }
               },

--- a/fabric/item/map/definition/2.1.0/schema.json
+++ b/fabric/item/map/definition/2.1.0/schema.json
@@ -356,7 +356,7 @@
           },
           "type": {
             "type": "string",
-            "description": "Type of the layer source"
+            "description": "Source type. Currently supported values are 'geojson' (Lakehouse GeoJSON file), 'pmtiles' (vector or raster tile archive), 'cog' (Cloud Optimized GeoTIFF), 'kusto' (KQL query results), 'ontology' (Ontology entity data), 'connection' (external service accessed through a connection), and 'unknown' (source type not yet identified). This is distinct from the layer setting's vector or raster rendering category."
           },
           "options": {
             "type": ["object", "null"],
@@ -372,7 +372,7 @@
                 "description": "Defines custom properties that are calculated using expressions against all the points within each cluster and added to the properties of each cluster point",
                 "additionalProperties": {
                   "type": "array",
-                  "description": "An aggregate expression in the form [operator, mapExpression], or [operator, initialValue, mapExpression] when an initial value is supplied. The operator is applied across all points in the cluster to the values produced by the map expression. Supported operators are '+', '*', 'max' and 'min' for numbers, and 'all' and 'any' for booleans."
+                  "description": "An aggregate expression in the form [operator, mapExpression], or [operator, initialValue, mapExpression] when an initial value is supplied. The optional initialValue is a Boolean for Boolean operators or a number for numeric operators. The operator is applied across all points in the cluster to the values produced by the map expression. Supported operators are '+', '*', 'max' and 'min' for numbers, and 'all' and 'any' for booleans."
                 }
               },
               "clusterField": {
@@ -468,7 +468,7 @@
             "properties": {
               "type": {
                 "type": "string",
-                "description": "Layer type (vector or raster)",
+                "description": "Rendering category: 'vector' for feature-based layers or vector tiles, and 'raster' for imagery or raster tiles. Applies to connection-backed and non-connection-backed layers; it is not conditional on sourceLayer being 'connection'.",
                 "enum": ["vector", "raster"]
               },
               "visible": {


### PR DESCRIPTION
v2.1.0 has not yet been released. This PR updates the definition to the final draft definition before release.

Add missing Map options, feature-service query settings, range and series-group styling, marker rotation, polygon extrusion metadata, data label settings, and heatmap color and weight expressions.